### PR TITLE
Add build/install instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ _testmain.go
 *.swp
 
 acbuild/acbuild
+
+# Used in building acbuild
+gopath/
+bin/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ This proposal introduces the concept of a command-line build tool, `acbuild`,
 that natively supports ACI builds and integrates well with shell, makefiles and
 other Unix tools.
 
-## Dependencies
+## Installation
+
+### Dependencies
 
 acbuild requires a handful of commands be available:
 
@@ -22,6 +24,41 @@ acbuild requires a handful of commands be available:
 - `mount`
 - `modprobe`
 - `tar`
+
+### Build from source
+
+Currently the only way to install `acbuild` is to build the program from
+source. Follow these steps to do so:
+
+1. Grab the source code for `acbuild` by `git clone`ing the source repository:
+
+```
+cd ~
+git clone git@github.com:appc/acbuild
+```
+
+2. Run the `build` script from the root source repository directory:
+
+```
+cd acbuild
+./build
+```
+
+3. A `bin/` directory will be created that contains the `acbuild` tool. To make
+   sure your shell can find this executable, append this directory to your
+   environment's `$PATH` variable. You can do this in your `.bashrc` or similar
+   file, for example:
+
+```
+vi ~/.bashrc
+```
+
+and put the following lines at the end of the file:
+
+```
+export ACBUILD_BIN_DIR=~/acbuild/bin
+export PATH=$PATH:$ACBUILD_BIN_DIR
+```
 
 ## Usage
 

--- a/build
+++ b/build
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e
+
+ORG_PATH="github.com/appc"
+REPO_PATH="${ORG_PATH}/acbuild"
+
+if [ ! -h gopath/src/${REPO_PATH} ]; then
+	mkdir -p gopath/src/${ORG_PATH}
+	ln -s ../../../.. gopath/src/${REPO_PATH} || exit 255
+fi
+
+export GOBIN=${PWD}/bin
+export GOPATH=${PWD}/gopath
+
+eval $(go env)
+export GOOS GOARCH
+
+if [ "${GOOS}" = "freebsd" ]; then
+    # /usr/bin/cc is clang on freebsd, but we need to tell it to go to
+    # make it generate proper flavour of code that doesn't emit
+    # warnings.
+    export CC=clang
+fi
+
+echo "Building acbuild..."
+go build -o $GOBIN/acbuild ${REPO_PATH}/acbuild


### PR DESCRIPTION
First thing folks typically want to know is how to build and install a
tool. So, we add a build script (ripped from appc/spec) and some
instructions to the README.md file.