### PR TITLE
*: Implemented file locking for each command

### DIFF
--- a/acbuild/annotation.go
+++ b/acbuild/annotation.go
@@ -59,11 +59,23 @@ func runAddAnno(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
+	lockfile, err := getLock()
+	if err != nil {
+		stderr("annotation add: %v", err)
+		return 1
+	}
+	defer func() {
+		if err := releaseLock(lockfile); err != nil {
+			stderr("annotation add: %v", err)
+			exit = 1
+		}
+	}()
+
 	if debug {
 		stderr("Adding annotation %q=%q", args[0], args[1])
 	}
 
-	err := lib.AddAnnotation(tmpacipath(), args[0], args[1])
+	err = lib.AddAnnotation(tmpacipath(), args[0], args[1])
 
 	if err != nil {
 		stderr("annotation add: %v", err)
@@ -83,11 +95,23 @@ func runRmAnno(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
+	lockfile, err := getLock()
+	if err != nil {
+		stderr("annotation remove: %v", err)
+		return 1
+	}
+	defer func() {
+		if err := releaseLock(lockfile); err != nil {
+			stderr("annotation remove: %v", err)
+			exit = 1
+		}
+	}()
+
 	if debug {
 		stderr("Removing annotation %q", args[0])
 	}
 
-	err := lib.RemoveAnnotation(tmpacipath(), args[0])
+	err = lib.RemoveAnnotation(tmpacipath(), args[0])
 
 	if err != nil {
 		stderr("annotation remove: %v", err)

--- a/acbuild/copy.go
+++ b/acbuild/copy.go
@@ -43,11 +43,23 @@ func runCopy(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
+	lockfile, err := getLock()
+	if err != nil {
+		stderr("copy: %v", err)
+		return 1
+	}
+	defer func() {
+		if err := releaseLock(lockfile); err != nil {
+			stderr("copy: %v", err)
+			exit = 1
+		}
+	}()
+
 	if debug {
 		stderr("Copying host:%s to aci:%s", args[0], args[1])
 	}
 
-	err := lib.Copy(tmpacipath(), args[0], args[1])
+	err = lib.Copy(tmpacipath(), args[0], args[1])
 
 	if err != nil {
 		stderr("copy: %v", err)

--- a/acbuild/dependency.go
+++ b/acbuild/dependency.go
@@ -70,11 +70,23 @@ func runAddDep(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
+	lockfile, err := getLock()
+	if err != nil {
+		stderr("dependency add: %v", err)
+		return 1
+	}
+	defer func() {
+		if err := releaseLock(lockfile); err != nil {
+			stderr("dependency add: %v", err)
+			exit = 1
+		}
+	}()
+
 	if debug {
 		stderr("Adding dependency %q", args[0])
 	}
 
-	err := lib.AddDependency(tmpacipath(), args[0], imageId,
+	err = lib.AddDependency(tmpacipath(), args[0], imageId,
 		types.Labels(labels), size)
 
 	if err != nil {
@@ -95,11 +107,23 @@ func runRmDep(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
+	lockfile, err := getLock()
+	if err != nil {
+		stderr("dependency remove: %v", err)
+		return 1
+	}
+	defer func() {
+		if err := releaseLock(lockfile); err != nil {
+			stderr("dependency remove: %v", err)
+			exit = 1
+		}
+	}()
+
 	if debug {
 		stderr("Removing dependency %q", args[0])
 	}
 
-	err := lib.RemoveDependency(tmpacipath(), args[0])
+	err = lib.RemoveDependency(tmpacipath(), args[0])
 
 	if err != nil {
 		stderr("dependency remove: %v", err)

--- a/acbuild/environment.go
+++ b/acbuild/environment.go
@@ -59,11 +59,23 @@ func runAddEnv(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
+	lockfile, err := getLock()
+	if err != nil {
+		stderr("environment add: %v", err)
+		return 1
+	}
+	defer func() {
+		if err := releaseLock(lockfile); err != nil {
+			stderr("environment add: %v", err)
+			exit = 1
+		}
+	}()
+
 	if debug {
 		stderr("Adding environment variable %q=%q", args[0], args[1])
 	}
 
-	err := lib.AddEnv(tmpacipath(), args[0], args[1])
+	err = lib.AddEnv(tmpacipath(), args[0], args[1])
 
 	if err != nil {
 		stderr("environment add: %v", err)
@@ -83,11 +95,23 @@ func runRemoveEnv(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
+	lockfile, err := getLock()
+	if err != nil {
+		stderr("environment remove: %v", err)
+		return 1
+	}
+	defer func() {
+		if err := releaseLock(lockfile); err != nil {
+			stderr("environment remove: %v", err)
+			exit = 1
+		}
+	}()
+
 	if debug {
 		stderr("Removing environment variable %q", args[0])
 	}
 
-	err := lib.RemoveEnv(tmpacipath(), args[0])
+	err = lib.RemoveEnv(tmpacipath(), args[0])
 
 	if err != nil {
 		stderr("environment remove: %v", err)

--- a/acbuild/label.go
+++ b/acbuild/label.go
@@ -58,11 +58,23 @@ func runAddLabel(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
+	lockfile, err := getLock()
+	if err != nil {
+		stderr("label add: %v", err)
+		return 1
+	}
+	defer func() {
+		if err := releaseLock(lockfile); err != nil {
+			stderr("label add: %v", err)
+			exit = 1
+		}
+	}()
+
 	if debug {
 		stderr("Adding label %q=%q", args[0], args[1])
 	}
 
-	err := lib.AddLabel(tmpacipath(), args[0], args[1])
+	err = lib.AddLabel(tmpacipath(), args[0], args[1])
 
 	if err != nil {
 		stderr("label add: %v", err)
@@ -82,11 +94,23 @@ func runRemoveLabel(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
+	lockfile, err := getLock()
+	if err != nil {
+		stderr("label remove: %v", err)
+		return 1
+	}
+	defer func() {
+		if err := releaseLock(lockfile); err != nil {
+			stderr("label remove: %v", err)
+			exit = 1
+		}
+	}()
+
 	if debug {
 		stderr("Removing label %q", args[0])
 	}
 
-	err := lib.RemoveLabel(tmpacipath(), args[0])
+	err = lib.RemoveLabel(tmpacipath(), args[0])
 
 	if err != nil {
 		stderr("label remove: %v", err)

--- a/acbuild/mount.go
+++ b/acbuild/mount.go
@@ -61,6 +61,18 @@ func runAddMount(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
+	lockfile, err := getLock()
+	if err != nil {
+		stderr("mount add: %v", err)
+		return 1
+	}
+	defer func() {
+		if err := releaseLock(lockfile); err != nil {
+			stderr("mount add: %v", err)
+			exit = 1
+		}
+	}()
+
 	if debug {
 		if readOnly {
 			stderr("Adding read only mount point %q=%q", args[0], args[1])
@@ -69,7 +81,7 @@ func runAddMount(cmd *cobra.Command, args []string) (exit int) {
 		}
 	}
 
-	err := lib.AddMount(tmpacipath(), args[0], args[1], readOnly)
+	err = lib.AddMount(tmpacipath(), args[0], args[1], readOnly)
 
 	if err != nil {
 		stderr("mount add: %v", err)
@@ -89,11 +101,23 @@ func runRmMount(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
+	lockfile, err := getLock()
+	if err != nil {
+		stderr("mount remove: %v", err)
+		return 1
+	}
+	defer func() {
+		if err := releaseLock(lockfile); err != nil {
+			stderr("mount remove: %v", err)
+			exit = 1
+		}
+	}()
+
 	if debug {
 		stderr("Removing mount point %q", args[0])
 	}
 
-	err := lib.RemoveMount(tmpacipath(), args[0])
+	err = lib.RemoveMount(tmpacipath(), args[0])
 
 	if err != nil {
 		stderr("mount remove: %v", err)

--- a/acbuild/port.go
+++ b/acbuild/port.go
@@ -70,6 +70,18 @@ func runAddPort(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
+	lockfile, err := getLock()
+	if err != nil {
+		stderr("port add: %v", err)
+		return 1
+	}
+	defer func() {
+		if err := releaseLock(lockfile); err != nil {
+			stderr("port add: %v", err)
+			exit = 1
+		}
+	}()
+
 	if debug {
 		stderr("Adding port %q=%q", args[0], args[1])
 	}
@@ -94,11 +106,23 @@ func runRmPort(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
+	lockfile, err := getLock()
+	if err != nil {
+		stderr("port remove: %v", err)
+		return 1
+	}
+	defer func() {
+		if err := releaseLock(lockfile); err != nil {
+			stderr("port remove: %v", err)
+			exit = 1
+		}
+	}()
+
 	if debug {
 		stderr("Removing port %q", args[0])
 	}
 
-	err := lib.RemovePort(tmpacipath(), args[0])
+	err = lib.RemovePort(tmpacipath(), args[0])
 
 	if err != nil {
 		stderr("port remove: %v", err)

--- a/acbuild/run.go
+++ b/acbuild/run.go
@@ -43,11 +43,23 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
+	lockfile, err := getLock()
+	if err != nil {
+		stderr("run: %v", err)
+		return 1
+	}
+	defer func() {
+		if err := releaseLock(lockfile); err != nil {
+			stderr("run: %v", err)
+			exit = 1
+		}
+	}()
+
 	if debug {
 		stderr("Running: %v", args)
 	}
 
-	err := lib.Run(tmpacipath(), depstorepath(), targetpath(), scratchpath(), workpath(), args, insecure)
+	err = lib.Run(tmpacipath(), depstorepath(), targetpath(), scratchpath(), workpath(), args, insecure)
 
 	if err != nil {
 		stderr("run: %v", err)

--- a/acbuild/set-exec.go
+++ b/acbuild/set-exec.go
@@ -40,11 +40,23 @@ func runSetExec(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
+	lockfile, err := getLock()
+	if err != nil {
+		stderr("set-exec: %v", err)
+		return 1
+	}
+	defer func() {
+		if err := releaseLock(lockfile); err != nil {
+			stderr("set-exec: %v", err)
+			exit = 1
+		}
+	}()
+
 	if debug {
 		stderr("Setting exec command %v", args)
 	}
 
-	err := lib.SetExec(tmpacipath(), args)
+	err = lib.SetExec(tmpacipath(), args)
 
 	if err != nil {
 		stderr("set-exec: %v", err)

--- a/acbuild/set-group.go
+++ b/acbuild/set-group.go
@@ -44,11 +44,23 @@ func runSetGroup(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
+	lockfile, err := getLock()
+	if err != nil {
+		stderr("set-group: %v", err)
+		return 1
+	}
+	defer func() {
+		if err := releaseLock(lockfile); err != nil {
+			stderr("set-group: %v", err)
+			exit = 1
+		}
+	}()
+
 	if debug {
 		stderr("Setting group to %s", args[0])
 	}
 
-	err := lib.SetGroup(tmpacipath(), args[0])
+	err = lib.SetGroup(tmpacipath(), args[0])
 
 	if err != nil {
 		stderr("set-group: %v", err)

--- a/acbuild/set-name.go
+++ b/acbuild/set-name.go
@@ -44,11 +44,23 @@ func runSetName(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
+	lockfile, err := getLock()
+	if err != nil {
+		stderr("set-name: %v", err)
+		return 1
+	}
+	defer func() {
+		if err := releaseLock(lockfile); err != nil {
+			stderr("set-name: %v", err)
+			exit = 1
+		}
+	}()
+
 	if debug {
 		stderr("Setting name of ACI to %s", args[0])
 	}
 
-	err := lib.SetName(tmpacipath(), args[0])
+	err = lib.SetName(tmpacipath(), args[0])
 
 	if err != nil {
 		stderr("set-name: %v", err)

--- a/acbuild/set-user.go
+++ b/acbuild/set-user.go
@@ -44,11 +44,23 @@ func runSetUser(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
+	lockfile, err := getLock()
+	if err != nil {
+		stderr("set-user: %v", err)
+		return 1
+	}
+	defer func() {
+		if err := releaseLock(lockfile); err != nil {
+			stderr("set-user: %v", err)
+			exit = 1
+		}
+	}()
+
 	if debug {
 		stderr("Setting user to %s", args[0])
 	}
 
-	err := lib.SetUser(tmpacipath(), args[0])
+	err = lib.SetUser(tmpacipath(), args[0])
 
 	if err != nil {
 		stderr("set-user: %v", err)


### PR DESCRIPTION
Each command now acquires a file lock on a file in the current working
context before performing any actions, and releases it upon completion.
This prevents concurrent invocations of acbuild from producing
unintended side effects.