### PR TITLE
copy: create parent directory before attempting to copy

### DIFF
--- a/lib/copy.go
+++ b/lib/copy.go
@@ -15,16 +15,26 @@
 package lib
 
 import (
+	"os"
 	"path"
 
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/aci"
-
-	"github.com/appc/acbuild/util"
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/coreos/rkt/pkg/fileutil"
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/coreos/rkt/pkg/uid"
 )
 
 // Copy will copy the directory/file at from to the path to inside the untarred
 // ACI at acipath.
 func Copy(acipath, from, to string) error {
-	err := util.Exec("cp", "-r", from, path.Join(acipath, aci.RootfsDir, to))
-	return err
+	target := path.Join(acipath, aci.RootfsDir, to)
+
+	dir, _ := path.Split(target)
+	if dir != "" {
+		err := os.MkdirAll(dir, 0755)
+		if err != nil {
+			return err
+		}
+	}
+
+	return fileutil.CopyTree(from, target, uid.NewBlankUidRange())
 }

--- a/lib/end.go
+++ b/lib/end.go
@@ -36,7 +36,7 @@ func End(tmpaci, output, contextpath string, overwrite bool) error {
 	}
 
 	if man.App != nil && testEq(man.App.Exec, placeholderexec) {
-		return fmt.Errorf("can't end build, run command was never set")
+		return fmt.Errorf("can't end build, exec command was never set")
 	}
 
 	if man.Name == types.ACIdentifier(placeholdername) {


### PR DESCRIPTION
For convenience, the copy command should create the parent directory for
the copy destination