### PR TITLE
util: UnTar function rewritten to use github.com/coreos/rkt/pkg/tar

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -44,6 +44,31 @@
 			"Rev": "e7fc03058804de5488baed8df5b89f3924b9ec9a"
 		},
 		{
+			"ImportPath": "github.com/coreos/rkt/pkg/fileutil",
+			"Comment": "v0.8.1-244-g64ae183",
+			"Rev": "64ae18343537f7e4f53ae27f1abd1fe533da2965"
+		},
+		{
+			"ImportPath": "github.com/coreos/rkt/pkg/multicall",
+			"Comment": "v0.8.1-244-g64ae183",
+			"Rev": "64ae18343537f7e4f53ae27f1abd1fe533da2965"
+		},
+		{
+			"ImportPath": "github.com/coreos/rkt/pkg/sys",
+			"Comment": "v0.8.1-244-g64ae183",
+			"Rev": "64ae18343537f7e4f53ae27f1abd1fe533da2965"
+		},
+		{
+			"ImportPath": "github.com/coreos/rkt/pkg/tar",
+			"Comment": "v0.8.1-244-g64ae183",
+			"Rev": "64ae18343537f7e4f53ae27f1abd1fe533da2965"
+		},
+		{
+			"ImportPath": "github.com/coreos/rkt/pkg/uid",
+			"Comment": "v0.8.1-244-g64ae183",
+			"Rev": "64ae18343537f7e4f53ae27f1abd1fe533da2965"
+		},
+		{
 			"ImportPath": "github.com/inconshreveable/mousetrap",
 			"Rev": "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
 		},
@@ -54,6 +79,10 @@
 		{
 			"ImportPath": "github.com/spf13/pflag",
 			"Rev": "67cbc198fd11dab704b214c1e629a97af392c085"
+		},
+		{
+			"ImportPath": "github.com/syndtr/gocapability/capability",
+			"Rev": "8e4cdcb3c22b40d5e330ade0b68cb2e2a3cf6f98"
 		},
 		{
 			"ImportPath": "golang.org/x/crypto/ssh/terminal",

--- a/Godeps/_workspace/src/github.com/coreos/rkt/pkg/fileutil/fileutil.go
+++ b/Godeps/_workspace/src/github.com/coreos/rkt/pkg/fileutil/fileutil.go
@@ -1,0 +1,201 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileutil
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/coreos/rkt/pkg/uid"
+
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/pkg/device"
+)
+
+func CopyRegularFile(src, dest string) (err error) {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+	destFile, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		e := destFile.Close()
+		if err == nil {
+			err = e
+		}
+	}()
+	if _, err := io.Copy(destFile, srcFile); err != nil {
+		return err
+	}
+	return nil
+}
+
+func CopySymlink(src, dest string) error {
+	symTarget, err := os.Readlink(src)
+	if err != nil {
+		return err
+	}
+	if err := os.Symlink(symTarget, dest); err != nil {
+		return err
+	}
+	return nil
+}
+
+func CopyTree(src, dest string, uidRange *uid.UidRange) error {
+	dirs := make(map[string][]syscall.Timespec)
+	copyWalker := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rootLess := path[len(src):]
+		target := filepath.Join(dest, rootLess)
+		mode := info.Mode()
+		switch {
+		case mode.IsDir():
+			err := os.Mkdir(target, mode.Perm())
+			if err != nil {
+				return err
+			}
+
+			dir, err := os.Open(target)
+			if err != nil {
+				return err
+			}
+			if err := dir.Chmod(mode); err != nil {
+				dir.Close()
+				return err
+			}
+			dir.Close()
+		case mode.IsRegular():
+			if err := CopyRegularFile(path, target); err != nil {
+				return err
+			}
+		case mode&os.ModeSymlink == os.ModeSymlink:
+			if err := CopySymlink(path, target); err != nil {
+				return err
+			}
+		case mode&os.ModeCharDevice == os.ModeCharDevice:
+			stat := syscall.Stat_t{}
+			if err := syscall.Stat(path, &stat); err != nil {
+				return err
+			}
+
+			dev := device.Makedev(device.Major(stat.Rdev), device.Minor(stat.Rdev))
+			mode := uint32(mode) | syscall.S_IFCHR
+			if err := syscall.Mknod(target, mode, int(dev)); err != nil {
+				return err
+			}
+		case mode&os.ModeDevice == os.ModeDevice:
+			stat := syscall.Stat_t{}
+			if err := syscall.Stat(path, &stat); err != nil {
+				return err
+			}
+
+			dev := device.Makedev(device.Major(stat.Rdev), device.Minor(stat.Rdev))
+			mode := uint32(mode) | syscall.S_IFBLK
+			if err := syscall.Mknod(target, mode, int(dev)); err != nil {
+				return err
+			}
+		case mode&os.ModeNamedPipe == os.ModeNamedPipe:
+			if err := syscall.Mkfifo(target, uint32(mode)); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unsupported mode: %v", mode)
+		}
+
+		var srcUid = info.Sys().(*syscall.Stat_t).Uid
+		var srcGid = info.Sys().(*syscall.Stat_t).Gid
+
+		shiftedUid, shiftedGid, err := uidRange.ShiftRange(srcUid, srcGid)
+		if err != nil {
+			return err
+		}
+
+		if err := os.Lchown(target, int(shiftedUid), int(shiftedGid)); err != nil {
+			return err
+		}
+
+		// lchown(2) says that, depending on the linux kernel version, it
+		// can change the file's mode also if executed as root. So call
+		// os.Chmod after it.
+		if mode&os.ModeSymlink != os.ModeSymlink {
+			if err := os.Chmod(target, mode); err != nil {
+				return err
+			}
+		}
+
+		ts, err := pathToTimespec(path)
+		if err != nil {
+			return err
+		}
+
+		if mode.IsDir() {
+			dirs[target] = ts
+		}
+		if mode&os.ModeSymlink != os.ModeSymlink {
+			if err := syscall.UtimesNano(target, ts); err != nil {
+				return err
+			}
+		} else {
+			if err := LUtimesNano(target, ts); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	if err := filepath.Walk(src, copyWalker); err != nil {
+		return err
+	}
+
+	// Restore dirs atime and mtime. This has to be done after copying
+	// as a file copying will change its parent directory's times.
+	for dirPath, ts := range dirs {
+		if err := syscall.UtimesNano(dirPath, ts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func pathToTimespec(name string) ([]syscall.Timespec, error) {
+	fi, err := os.Lstat(name)
+	if err != nil {
+		return nil, err
+	}
+	mtime := fi.ModTime()
+	stat := fi.Sys().(*syscall.Stat_t)
+	atime := time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec))
+	return []syscall.Timespec{TimeToTimespec(atime), TimeToTimespec(mtime)}, nil
+}
+
+// TODO(sgotti) use UTIMES_OMIT on linux if Time.IsZero ?
+func TimeToTimespec(time time.Time) (ts syscall.Timespec) {
+	nsec := int64(0)
+	if !time.IsZero() {
+		nsec = time.UnixNano()
+	}
+	return syscall.NsecToTimespec(nsec)
+}

--- a/Godeps/_workspace/src/github.com/coreos/rkt/pkg/fileutil/utimes_linux.go
+++ b/Godeps/_workspace/src/github.com/coreos/rkt/pkg/fileutil/utimes_linux.go
@@ -1,0 +1,43 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// These functions are from github.com/docker/docker/pkg/system
+
+// TODO(sgotti) waiting for a utimensat functions accepting flags and a
+// LUtimesNano using it in https://github.com/golang/sys/
+
+package fileutil
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+func LUtimesNano(path string, ts []syscall.Timespec) error {
+	// These are not currently available in syscall
+	AT_FDCWD := -100
+	AT_SYMLINK_NOFOLLOW := 0x100
+
+	var _path *byte
+	_path, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return err
+	}
+
+	if _, _, err := syscall.Syscall6(syscall.SYS_UTIMENSAT, uintptr(AT_FDCWD), uintptr(unsafe.Pointer(_path)), uintptr(unsafe.Pointer(&ts[0])), uintptr(AT_SYMLINK_NOFOLLOW), 0, 0); err != 0 && err != syscall.ENOSYS {
+		return err
+	}
+
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/coreos/rkt/pkg/fileutil/utimes_unsupported.go
+++ b/Godeps/_workspace/src/github.com/coreos/rkt/pkg/fileutil/utimes_unsupported.go
@@ -1,0 +1,25 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !linux
+
+// These functions are from github.com/docker/docker/pkg/system
+
+package fileutil
+
+import "syscall"
+
+func LUtimesNano(path string, ts []syscall.Timespec) error {
+	return ErrNotSupportedPlatform
+}

--- a/Godeps/_workspace/src/github.com/coreos/rkt/pkg/fileutil/xattrs_linux.go
+++ b/Godeps/_workspace/src/github.com/coreos/rkt/pkg/fileutil/xattrs_linux.go
@@ -1,0 +1,77 @@
+// Copyright 2014 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+// These functions are from github.com/docker/docker/pkg/system
+
+package fileutil
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// Returns a nil slice and nil error if the xattr is not set
+func Lgetxattr(path string, attr string) ([]byte, error) {
+	pathBytes, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+	attrBytes, err := syscall.BytePtrFromString(attr)
+	if err != nil {
+		return nil, err
+	}
+
+	dest := make([]byte, 128)
+	destBytes := unsafe.Pointer(&dest[0])
+	sz, _, errno := syscall.Syscall6(syscall.SYS_LGETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(destBytes), uintptr(len(dest)), 0, 0)
+	if errno == syscall.ENODATA {
+		return nil, nil
+	}
+	if errno == syscall.ERANGE {
+		dest = make([]byte, sz)
+		destBytes := unsafe.Pointer(&dest[0])
+		sz, _, errno = syscall.Syscall6(syscall.SYS_LGETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(destBytes), uintptr(len(dest)), 0, 0)
+	}
+	if errno != 0 {
+		return nil, errno
+	}
+
+	return dest[:sz], nil
+}
+
+var _zero uintptr
+
+func Lsetxattr(path string, attr string, data []byte, flags int) error {
+	pathBytes, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return err
+	}
+	attrBytes, err := syscall.BytePtrFromString(attr)
+	if err != nil {
+		return err
+	}
+	var dataBytes unsafe.Pointer
+	if len(data) > 0 {
+		dataBytes = unsafe.Pointer(&data[0])
+	} else {
+		dataBytes = unsafe.Pointer(&_zero)
+	}
+	_, _, errno := syscall.Syscall6(syscall.SYS_LSETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(dataBytes), uintptr(len(data)), uintptr(flags), 0)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/coreos/rkt/pkg/fileutil/xattrs_unsupported.go
+++ b/Godeps/_workspace/src/github.com/coreos/rkt/pkg/fileutil/xattrs_unsupported.go
@@ -1,0 +1,27 @@
+// Copyright 2014 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !linux
+
+// These functions are from github.com/docker/docker/pkg/system
+
+package fileutil
+
+func Lgetxattr(path string, attr string) ([]byte, error) {
+	return nil, ErrNotSupportedPlatform
+}
+
+func Lsetxattr(path string, attr string, data []byte, flags int) error {
+	return ErrNotSupportedPlatform
+}

--- a/Godeps/_workspace/src/github.com/coreos/rkt/pkg/multicall/multicall.go
+++ b/Godeps/_workspace/src/github.com/coreos/rkt/pkg/multicall/multicall.go
@@ -1,0 +1,87 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// inspired by github.com/docker/docker/pkg/reexec
+
+//+build linux
+
+package multicall
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+var exePath string
+
+func init() {
+	// save the program path
+	var err error
+	exePath, err = os.Readlink("/proc/self/exe")
+	if err != nil {
+		panic("cannot get current executable")
+	}
+}
+
+type commandFn func() error
+
+var commands = make(map[string]commandFn)
+
+// Entrypoint provides the access to a multicall command.
+type Entrypoint string
+
+// Add adds a new multicall command. name is the command name and fn is the
+// function that will be executed for the specified command. It returns the
+// related Entrypoint.
+// Packages adding new multicall commands should call Add in their init
+// function.
+func Add(name string, fn commandFn) Entrypoint {
+	if _, ok := commands[name]; ok {
+		panic(fmt.Errorf("command with name %q already exists", name))
+	}
+	commands[name] = fn
+	return Entrypoint(name)
+}
+
+// MaybeExec should be called at the start of the program, if the process argv[0] is
+// a name registered with multicall, the related function will be executed.
+// If the functions returns an error, it will be printed to stderr and will
+// exit with an exit status of 1, otherwise it will exit with a 0 exit
+// status.
+func MaybeExec() {
+	name := os.Args[0]
+	if fn, ok := commands[name]; ok {
+		if err := fn(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+}
+
+// Cmd will prepare the *exec.Cmd for the given entrypoint, configured with the
+// provided args.
+func (e Entrypoint) Cmd(args ...string) *exec.Cmd {
+	// append the Entrypoint as argv[0]
+	args = append([]string{string(e)}, args...)
+	return &exec.Cmd{
+		Path: exePath,
+		Args: args,
+		SysProcAttr: &syscall.SysProcAttr{
+			Pdeathsig: syscall.SIGTERM,
+		},
+	}
+}

--- a/Godeps/_workspace/src/github.com/coreos/rkt/pkg/sys/capability.go
+++ b/Godeps/_workspace/src/github.com/coreos/rkt/pkg/sys/capability.go
@@ -1,0 +1,35 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sys
+
+import (
+	"os"
+
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/syndtr/gocapability/capability"
+)
+
+// HasChrootCapability checks if the current process has the CAP_SYS_CHROOT
+// capability
+func HasChrootCapability() bool {
+	// Checking the capabilities should be enough, but in case there're
+	// problem retrieving them, fallback checking for the effective uid
+	// (hoping it hasn't dropped its CAP_SYS_CHROOT).
+	caps, err := capability.NewPid(0)
+	if err == nil {
+		return caps.Get(capability.EFFECTIVE, capability.CAP_SYS_CHROOT)
+	} else {
+		return os.Geteuid() == 0
+	}
+}

--- a/Godeps/_workspace/src/github.com/coreos/rkt/pkg/sys/sys.go
+++ b/Godeps/_workspace/src/github.com/coreos/rkt/pkg/sys/sys.go
@@ -1,0 +1,32 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sys
+
+import (
+	"syscall"
+)
+
+// CloseOnExec sets or clears FD_CLOEXEC flag on a file descriptor
+func CloseOnExec(fd int, set bool) error {
+	flag := uintptr(0)
+	if set {
+		flag = syscall.FD_CLOEXEC
+	}
+	_, _, err := syscall.RawSyscall(syscall.SYS_FCNTL, uintptr(fd), syscall.F_SETFD, flag)
+	if err != 0 {
+		return syscall.Errno(err)
+	}
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/coreos/rkt/pkg/sys/sys_linux.go
+++ b/Godeps/_workspace/src/github.com/coreos/rkt/pkg/sys/sys_linux.go
@@ -1,0 +1,25 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sys
+
+import "syscall"
+
+func Syncfs(fd int) error {
+	_, _, err := syscall.RawSyscall(SYS_SYNCFS, uintptr(fd), 0, 0)
+	if err != 0 {
+		return syscall.Errno(err)
+	}
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/coreos/rkt/pkg/sys/sys_linux_386.go
+++ b/Godeps/_workspace/src/github.com/coreos/rkt/pkg/sys/sys_linux_386.go
@@ -1,0 +1,19 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sys
+
+const (
+	SYS_SYNCFS = 344
+)

--- a/Godeps/_workspace/src/github.com/coreos/rkt/pkg/sys/sys_linux_amd64.go
+++ b/Godeps/_workspace/src/github.com/coreos/rkt/pkg/sys/sys_linux_amd64.go
@@ -1,0 +1,19 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sys
+
+const (
+	SYS_SYNCFS = 306
+)

--- a/Godeps/_workspace/src/github.com/coreos/rkt/pkg/sys/sys_linux_arm.go
+++ b/Godeps/_workspace/src/github.com/coreos/rkt/pkg/sys/sys_linux_arm.go
@@ -1,0 +1,19 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sys
+
+const (
+	SYS_SYNCFS = 373
+)

--- a/Godeps/_workspace/src/github.com/coreos/rkt/pkg/sys/sys_linux_arm64.go
+++ b/Godeps/_workspace/src/github.com/coreos/rkt/pkg/sys/sys_linux_arm64.go
@@ -1,0 +1,23 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux,arm64
+
+package sys
+
+import "syscall"
+
+const (
+	SYS_SYNCFS = syscall.SYS_SYNCFS
+)

--- a/Godeps/_workspace/src/github.com/coreos/rkt/pkg/tar/chroot.go
+++ b/Godeps/_workspace/src/github.com/coreos/rkt/pkg/tar/chroot.go
@@ -1,0 +1,127 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tar
+
+import (
+	"archive/tar"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/coreos/rkt/pkg/multicall"
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/coreos/rkt/pkg/sys"
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/coreos/rkt/pkg/uid"
+)
+
+const (
+	multicallName = "extracttar"
+	fileMapFdNum  = 3
+)
+
+var mcEntrypoint multicall.Entrypoint
+
+func init() {
+	mcEntrypoint = multicall.Add(multicallName, extractTarCommand)
+}
+
+func extractTarCommand() error {
+	if len(os.Args) != 5 {
+		return fmt.Errorf("incorrect number of arguments. Usage: %s DIR {true|false} uidShift uidCount", multicallName)
+	}
+	if !sys.HasChrootCapability() {
+		return fmt.Errorf("chroot capability not available.")
+	}
+	dir := os.Args[1]
+	if !filepath.IsAbs(dir) {
+		return fmt.Errorf("dir %s must be an absolute path", dir)
+	}
+	overwrite, err := strconv.ParseBool(os.Args[2])
+	if err != nil {
+		return fmt.Errorf("error parsing overwrite argument: %v", err)
+	}
+
+	us, err := strconv.ParseUint(os.Args[3], 10, 32)
+	if err != nil {
+		return fmt.Errorf("error parsing uidShift argument: %v", err)
+	}
+	uc, err := strconv.ParseUint(os.Args[4], 10, 32)
+	if err != nil {
+		return fmt.Errorf("error parsing uidShift argument: %v", err)
+	}
+
+	uidRange := &uid.UidRange{Shift: uint32(us), Count: uint32(uc)}
+
+	if err := syscall.Chroot(dir); err != nil {
+		return fmt.Errorf("failed to chroot in %s: %v", dir, err)
+	}
+	if err := syscall.Chdir("/"); err != nil {
+		return fmt.Errorf("failed to chdir: %v", err)
+	}
+	fileMapFile := os.NewFile(uintptr(fileMapFdNum), "fileMap")
+
+	fileMap := map[string]struct{}{}
+	if err := json.NewDecoder(fileMapFile).Decode(&fileMap); err != nil {
+		return fmt.Errorf("error decoding fileMap: %v", err)
+	}
+	if err := extractTar(tar.NewReader(os.Stdin), overwrite, fileMap, uidRange); err != nil {
+		return fmt.Errorf("error extracting tar: %v", err)
+	}
+
+	// flush remaining bytes
+	io.Copy(ioutil.Discard, os.Stdin)
+
+	return nil
+}
+
+// ExtractTar extracts a tarball (from a io.Reader) into the given directory
+// if pwl is not nil, only the paths in the map are extracted.
+// If overwrite is true, existing files will be overwritten.
+// The extraction is executed by fork/exec()ing a new process. The new process
+// needs the CAP_SYS_CHROOT capability.
+func ExtractTar(rs io.Reader, dir string, overwrite bool, uidRange *uid.UidRange, pwl PathWhitelistMap) error {
+	r, w, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+	enc := json.NewEncoder(w)
+	cmd := mcEntrypoint.Cmd(dir, strconv.FormatBool(overwrite),
+		strconv.FormatUint(uint64(uidRange.Shift), 10),
+		strconv.FormatUint(uint64(uidRange.Count), 10))
+	cmd.ExtraFiles = []*os.File{r}
+
+	cmd.Stdin = rs
+	encodeCh := make(chan error)
+	go func() {
+		encodeCh <- enc.Encode(pwl)
+	}()
+
+	out, err := cmd.CombinedOutput()
+
+	// read from blocking encodeCh to release the goroutine
+	encodeErr := <-encodeCh
+	if err != nil {
+		return fmt.Errorf("extracttar error: %v, output: %s", err, out)
+	}
+	if encodeErr != nil {
+		return fmt.Errorf("extracttar failed to json encode filemap: %v", encodeErr)
+	}
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/coreos/rkt/pkg/tar/tar.go
+++ b/Godeps/_workspace/src/github.com/coreos/rkt/pkg/tar/tar.go
@@ -1,0 +1,234 @@
+// Copyright 2014 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tar contains helper functions for working with tar files
+package tar
+
+import (
+	"archive/tar"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/pkg/device"
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/coreos/rkt/pkg/fileutil"
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/coreos/rkt/pkg/uid"
+)
+
+const DEFAULT_DIR_MODE os.FileMode = 0755
+
+var ErrNotSupportedPlatform = errors.New("platform and architecture is not supported")
+
+// Map of paths that should be whitelisted. The paths should be relative to the
+// root of the tar file and should be cleaned (for example using filepath.Clean)
+type PathWhitelistMap map[string]struct{}
+
+// extractTar extracts a tarball (from a tar.Reader) into the root directory
+// if pwl is not nil, only the paths in the map are extracted.
+// If overwrite is true, existing files will be overwritten.
+func extractTar(tr *tar.Reader, overwrite bool, pwl PathWhitelistMap, uidRange *uid.UidRange) error {
+	um := syscall.Umask(0)
+	defer syscall.Umask(um)
+
+	dirhdrs := []*tar.Header{}
+Tar:
+	for {
+		hdr, err := tr.Next()
+		switch err {
+		case io.EOF:
+			break Tar
+		case nil:
+			if pwl != nil {
+				relpath := filepath.Clean(hdr.Name)
+				if _, ok := pwl[relpath]; !ok {
+					continue
+				}
+			}
+			err = extractFile(tr, hdr, overwrite, uidRange)
+			if err != nil {
+				return fmt.Errorf("error extracting tarball: %v", err)
+			}
+			if hdr.Typeflag == tar.TypeDir {
+				dirhdrs = append(dirhdrs, hdr)
+			}
+		default:
+			return fmt.Errorf("error extracting tarball: %v", err)
+		}
+	}
+
+	// Restore dirs atime and mtime. This has to be done after extracting
+	// as a file extraction will change its parent directory's times.
+	for _, hdr := range dirhdrs {
+		p := filepath.Join("/", hdr.Name)
+		if err := syscall.UtimesNano(p, HdrToTimespec(hdr)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// extractFile extracts the file described by hdr from the given tarball into
+// the root directory.
+// If overwrite is true, existing files will be overwritten.
+func extractFile(tr *tar.Reader, hdr *tar.Header, overwrite bool, uidRange *uid.UidRange) error {
+	p := filepath.Join("/", hdr.Name)
+	fi := hdr.FileInfo()
+	typ := hdr.Typeflag
+	if overwrite {
+		info, err := os.Lstat(p)
+		switch {
+		case os.IsNotExist(err):
+		case err == nil:
+			// If the old and new paths are both dirs do nothing or
+			// RemoveAll will remove all dir's contents
+			if !info.IsDir() || typ != tar.TypeDir {
+				err := os.RemoveAll(p)
+				if err != nil {
+					return err
+				}
+			}
+		default:
+			return err
+		}
+	}
+
+	// Create parent dir if it doesn't exist
+	if err := os.MkdirAll(filepath.Dir(p), DEFAULT_DIR_MODE); err != nil {
+		return err
+	}
+	switch {
+	case typ == tar.TypeReg || typ == tar.TypeRegA:
+		f, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR, fi.Mode())
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(f, tr)
+		if err != nil {
+			f.Close()
+			return err
+		}
+		f.Close()
+	case typ == tar.TypeDir:
+		if err := os.MkdirAll(p, fi.Mode()); err != nil {
+			return err
+		}
+		dir, err := os.Open(p)
+		if err != nil {
+			return err
+		}
+		if err := dir.Chmod(fi.Mode()); err != nil {
+			dir.Close()
+			return err
+		}
+		dir.Close()
+	case typ == tar.TypeLink:
+		dest := filepath.Join("/", hdr.Linkname)
+		if err := os.Link(dest, p); err != nil {
+			return err
+		}
+	case typ == tar.TypeSymlink:
+		if err := os.Symlink(hdr.Linkname, p); err != nil {
+			return err
+		}
+	case typ == tar.TypeChar:
+		dev := device.Makedev(uint(hdr.Devmajor), uint(hdr.Devminor))
+		mode := uint32(fi.Mode()) | syscall.S_IFCHR
+		if err := syscall.Mknod(p, mode, int(dev)); err != nil {
+			return err
+		}
+	case typ == tar.TypeBlock:
+		dev := device.Makedev(uint(hdr.Devmajor), uint(hdr.Devminor))
+		mode := uint32(fi.Mode()) | syscall.S_IFBLK
+		if err := syscall.Mknod(p, mode, int(dev)); err != nil {
+			return err
+		}
+	case typ == tar.TypeFifo:
+		if err := syscall.Mkfifo(p, uint32(fi.Mode())); err != nil {
+			return err
+		}
+	// TODO(jonboulle): implement other modes
+	default:
+		return fmt.Errorf("unsupported type: %v", typ)
+	}
+
+	shiftedUid, shiftedGid, err := uidRange.ShiftRange(uint32(hdr.Uid), uint32(hdr.Gid))
+	if err != nil {
+		return err
+	}
+	if err := os.Lchown(p, int(shiftedUid), int(shiftedGid)); err != nil {
+		return err
+	}
+
+	// lchown(2) says that, depending on the linux kernel version, it
+	// can change the file's mode also if executed as root. So call
+	// os.Chmod after it.
+	if typ != tar.TypeSymlink {
+		if err := os.Chmod(p, fi.Mode()); err != nil {
+			return err
+		}
+	}
+
+	// Restore entry atime and mtime.
+	// Use special function LUtimesNano not available on go's syscall package because we
+	// have to restore symlink's times and not the referenced file times.
+	ts := HdrToTimespec(hdr)
+	if hdr.Typeflag != tar.TypeSymlink {
+		if err := syscall.UtimesNano(p, ts); err != nil {
+			return err
+		}
+	} else {
+		if err := fileutil.LUtimesNano(p, ts); err != nil && err != ErrNotSupportedPlatform {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// extractFileFromTar extracts a regular file from the given tar, returning its
+// contents as a byte slice
+func extractFileFromTar(tr *tar.Reader, file string) ([]byte, error) {
+	for {
+		hdr, err := tr.Next()
+		switch err {
+		case io.EOF:
+			return nil, fmt.Errorf("file not found")
+		case nil:
+			if filepath.Clean(hdr.Name) != filepath.Clean(file) {
+				continue
+			}
+			switch hdr.Typeflag {
+			case tar.TypeReg:
+			case tar.TypeRegA:
+			default:
+				return nil, fmt.Errorf("requested file not a regular file")
+			}
+			buf, err := ioutil.ReadAll(tr)
+			if err != nil {
+				return nil, fmt.Errorf("error extracting tarball: %v", err)
+			}
+			return buf, nil
+		default:
+			return nil, fmt.Errorf("error extracting tarball: %v", err)
+		}
+	}
+}
+
+func HdrToTimespec(hdr *tar.Header) []syscall.Timespec {
+	return []syscall.Timespec{fileutil.TimeToTimespec(hdr.AccessTime), fileutil.TimeToTimespec(hdr.ModTime)}
+}

--- a/Godeps/_workspace/src/github.com/coreos/rkt/pkg/tar/tar_test.go
+++ b/Godeps/_workspace/src/github.com/coreos/rkt/pkg/tar/tar_test.go
@@ -1,0 +1,694 @@
+// Copyright 2014 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tar
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/coreos/rkt/pkg/multicall"
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/coreos/rkt/pkg/sys"
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/coreos/rkt/pkg/uid"
+)
+
+func init() {
+	multicall.MaybeExec()
+}
+
+type testTarEntry struct {
+	header   *tar.Header
+	contents string
+}
+
+func newTestTar(entries []*testTarEntry) (string, error) {
+	t, err := ioutil.TempFile("", "test-tar")
+	if err != nil {
+		return "", err
+	}
+	defer t.Close()
+	tw := tar.NewWriter(t)
+	for _, entry := range entries {
+		// Add default mode
+		if entry.header.Mode == 0 {
+			if entry.header.Typeflag == tar.TypeDir {
+				entry.header.Mode = 0755
+			} else {
+				entry.header.Mode = 0644
+			}
+		}
+		// Add calling user uid and gid or tests will fail
+		entry.header.Uid = os.Getuid()
+		entry.header.Gid = os.Getgid()
+		if err := tw.WriteHeader(entry.header); err != nil {
+			return "", err
+		}
+		if _, err := io.WriteString(tw, entry.contents); err != nil {
+			return "", err
+		}
+	}
+	if err := tw.Close(); err != nil {
+		return "", err
+	}
+	return t.Name(), nil
+}
+
+type fileInfo struct {
+	path     string
+	typeflag byte
+	size     int64
+	contents string
+	mode     os.FileMode
+}
+
+func fileInfoSliceToMap(slice []*fileInfo) map[string]*fileInfo {
+	fim := make(map[string]*fileInfo, len(slice))
+	for _, fi := range slice {
+		fim[fi.path] = fi
+	}
+	return fim
+}
+
+func checkExpectedFiles(dir string, expectedFiles map[string]*fileInfo) error {
+	files := make(map[string]*fileInfo)
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		fm := info.Mode()
+		if path == dir {
+			return nil
+		}
+		relpath, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		switch {
+		case fm.IsRegular():
+			files[relpath] = &fileInfo{path: relpath, typeflag: tar.TypeReg, size: info.Size(), mode: info.Mode().Perm()}
+		case info.IsDir():
+			files[relpath] = &fileInfo{path: relpath, typeflag: tar.TypeDir, mode: info.Mode().Perm()}
+		case fm&os.ModeSymlink != 0:
+			files[relpath] = &fileInfo{path: relpath, typeflag: tar.TypeSymlink, mode: info.Mode()}
+		default:
+			return fmt.Errorf("file mode not handled: %v", fm)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Set defaults for not specified expected file mode
+	for _, ef := range expectedFiles {
+		if ef.mode == 0 {
+			if ef.typeflag == tar.TypeDir {
+				ef.mode = 0755
+			} else {
+				ef.mode = 0644
+			}
+		}
+	}
+
+	for _, ef := range expectedFiles {
+		_, ok := files[ef.path]
+		if !ok {
+			return fmt.Errorf("Expected file %q not in files", ef.path)
+		}
+
+	}
+
+	for _, file := range files {
+		ef, ok := expectedFiles[file.path]
+		if !ok {
+			return fmt.Errorf("file %q not in expectedFiles", file.path)
+		}
+		if ef.typeflag != file.typeflag {
+			return fmt.Errorf("file %q: file type differs: wanted: %d, got: %d", file.path, ef.typeflag, file.typeflag)
+		}
+		if ef.typeflag == tar.TypeReg {
+			if ef.size != file.size {
+				return fmt.Errorf("file %q: size differs: wanted %d, wanted: %d", file.path, ef.size, file.size)
+			}
+			if ef.contents != "" {
+				buf, err := ioutil.ReadFile(filepath.Join(dir, file.path))
+				if err != nil {
+					return fmt.Errorf("unexpected error: %v", err)
+				}
+				if string(buf) != ef.contents {
+					return fmt.Errorf("unexpected contents, wanted: %s, got: %s", ef.contents, buf)
+				}
+
+			}
+		}
+		// Check modes but ignore symlinks
+		if ef.mode != file.mode && ef.typeflag != tar.TypeSymlink {
+			return fmt.Errorf("file %q: mode differs: wanted %#o, got: %#o", file.path, ef.mode, file.mode)
+		}
+
+	}
+	return nil
+}
+
+func TestExtractTarFolders(t *testing.T) {
+	if !sys.HasChrootCapability() {
+		t.Skipf("chroot capability not available. Disabling test.")
+	}
+
+	entries := []*testTarEntry{
+		{
+			contents: "foo",
+			header: &tar.Header{
+				Name: "deep/folder/foo.txt",
+				Size: 3,
+			},
+		},
+		{
+			header: &tar.Header{
+				Name:     "deep/folder/",
+				Typeflag: tar.TypeDir,
+				Mode:     int64(0747),
+			},
+		},
+		{
+			contents: "bar",
+			header: &tar.Header{
+				Name: "deep/folder/bar.txt",
+				Size: 3,
+			},
+		},
+		{
+			header: &tar.Header{
+				Name:     "deep/folder2/symlink.txt",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "deep/folder/foo.txt",
+			},
+		},
+		{
+			header: &tar.Header{
+				Name:     "deep/folder2/",
+				Typeflag: tar.TypeDir,
+				Mode:     int64(0747),
+			},
+		},
+		{
+			contents: "bar",
+			header: &tar.Header{
+				Name: "deep/folder2/bar.txt",
+				Size: 3,
+			},
+		},
+		{
+			header: &tar.Header{
+				Name:     "deep/deep/folder",
+				Typeflag: tar.TypeDir,
+				Mode:     int64(0755),
+			},
+		},
+		{
+			header: &tar.Header{
+				Name:     "deep/deep/",
+				Typeflag: tar.TypeDir,
+				Mode:     int64(0747),
+			},
+		},
+	}
+
+	testTarPath, err := newTestTar(entries)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	defer os.Remove(testTarPath)
+	containerTar, err := os.Open(testTarPath)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	defer containerTar.Close()
+	tmpdir, err := ioutil.TempDir("", "rkt-temp-dir")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	os.RemoveAll(tmpdir)
+	err = os.MkdirAll(tmpdir, 0755)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	defer os.RemoveAll(tmpdir)
+	err = ExtractTar(containerTar, tmpdir, false, uid.NewBlankUidRange(), nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	matches, err := filepath.Glob(filepath.Join(tmpdir, "deep/folder/*.txt"))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(matches) != 2 {
+		t.Errorf("unexpected number of files found: %d, wanted 2", len(matches))
+	}
+	matches, err = filepath.Glob(filepath.Join(tmpdir, "deep/folder2/*.txt"))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(matches) != 2 {
+		t.Errorf("unexpected number of files found: %d, wanted 2", len(matches))
+	}
+
+	dirInfo, err := os.Lstat(filepath.Join(tmpdir, "deep/folder"))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	} else if dirInfo.Mode().Perm() != os.FileMode(0747) {
+		t.Errorf("unexpected dir mode: %s", dirInfo.Mode())
+	}
+	dirInfo, err = os.Lstat(filepath.Join(tmpdir, "deep/deep"))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	} else if dirInfo.Mode().Perm() != os.FileMode(0747) {
+		t.Errorf("unexpected dir mode: %s", dirInfo.Mode())
+	}
+}
+
+func TestExtractTarFileToBuf(t *testing.T) {
+	entries := []*testTarEntry{
+		{
+			header: &tar.Header{
+				Name:     "folder/",
+				Typeflag: tar.TypeDir,
+				Mode:     int64(0747),
+			},
+		},
+		{
+			contents: "foo",
+			header: &tar.Header{
+				Name: "folder/foo.txt",
+				Size: 3,
+			},
+		},
+		{
+			contents: "bar",
+			header: &tar.Header{
+				Name: "folder/bar.txt",
+				Size: 3,
+			},
+		},
+		{
+			header: &tar.Header{
+				Name:     "folder/symlink.txt",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "folder/foo.txt",
+			},
+		},
+	}
+	testTarPath, err := newTestTar(entries)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer os.Remove(testTarPath)
+	containerTar1, err := os.Open(testTarPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer containerTar1.Close()
+
+	tr := tar.NewReader(containerTar1)
+	buf, err := extractFileFromTar(tr, "folder/foo.txt")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if string(buf) != "foo" {
+		t.Errorf("unexpected contents, wanted: %s, got: %s", "foo", buf)
+	}
+
+	containerTar2, err := os.Open(testTarPath)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	defer containerTar2.Close()
+	tr = tar.NewReader(containerTar2)
+	buf, err = extractFileFromTar(tr, "folder/symlink.txt")
+	if err == nil {
+		t.Errorf("expected error")
+	}
+}
+
+func TestExtractTarPWL(t *testing.T) {
+	if !sys.HasChrootCapability() {
+		t.Skipf("chroot capability not available. Disabling test.")
+	}
+	entries := []*testTarEntry{
+		{
+			header: &tar.Header{
+				Name:     "folder/",
+				Typeflag: tar.TypeDir,
+				Mode:     int64(0747),
+			},
+		},
+		{
+			contents: "foo",
+			header: &tar.Header{
+				Name: "folder/foo.txt",
+				Size: 3,
+			},
+		},
+		{
+			contents: "bar",
+			header: &tar.Header{
+				Name: "folder/bar.txt",
+				Size: 3,
+			},
+		},
+		{
+			header: &tar.Header{
+				Name:     "folder/symlink.txt",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "folder/foo.txt",
+			},
+		},
+	}
+	testTarPath, err := newTestTar(entries)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	defer os.Remove(testTarPath)
+	containerTar, err := os.Open(testTarPath)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	defer containerTar.Close()
+	tmpdir, err := ioutil.TempDir("", "rkt-temp-dir")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	pwl := make(PathWhitelistMap)
+	pwl["folder/foo.txt"] = struct{}{}
+	err = ExtractTar(containerTar, tmpdir, false, uid.NewBlankUidRange(), pwl)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	matches, err := filepath.Glob(filepath.Join(tmpdir, "folder/*.txt"))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Errorf("unexpected number of files found: %d, wanted 1", len(matches))
+	}
+}
+
+func TestExtractTarOverwrite(t *testing.T) {
+	if !sys.HasChrootCapability() {
+		t.Skipf("chroot capability not available. Disabling test.")
+	}
+
+	tmpdir, err := ioutil.TempDir("", "rkt-temp-dir")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	entries := []*testTarEntry{
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "hello.txt",
+				Size: 5,
+			},
+		},
+		{
+			header: &tar.Header{
+				Name:     "afolder",
+				Typeflag: tar.TypeDir,
+			},
+		},
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "afolder/hello.txt",
+				Size: 5,
+			},
+		},
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "afile",
+				Size: 5,
+			},
+		},
+		{
+			header: &tar.Header{
+				Name:     "folder01",
+				Typeflag: tar.TypeDir,
+			},
+		},
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "folder01/file01",
+				Size: 5,
+			},
+		},
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "filesymlinked",
+				Size: 5,
+			},
+		},
+		{
+			header: &tar.Header{
+				Name:     "linktofile",
+				Linkname: "filesymlinked",
+				Typeflag: tar.TypeSymlink,
+			},
+		},
+
+		{
+			header: &tar.Header{
+				Name:     "dirsymlinked",
+				Typeflag: tar.TypeDir,
+			},
+		},
+		{
+			header: &tar.Header{
+				Name:     "linktodir",
+				Linkname: "dirsymlinked",
+				Typeflag: tar.TypeSymlink,
+			},
+		},
+	}
+
+	testTarPath, err := newTestTar(entries)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer os.Remove(testTarPath)
+	containerTar1, err := os.Open(testTarPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer containerTar1.Close()
+	err = ExtractTar(containerTar1, tmpdir, false, uid.NewBlankUidRange(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Now overwrite:
+	// a file with a new file
+	// a dir with a file
+	entries = []*testTarEntry{
+		{
+			contents: "newhello",
+			header: &tar.Header{
+				Name: "hello.txt",
+				Size: 8,
+			},
+		},
+		// Now this is a file
+		{
+			contents: "nowafile",
+			header: &tar.Header{
+				Name:     "afolder",
+				Typeflag: tar.TypeReg,
+				Size:     8,
+			},
+		},
+		// Now this is a dir
+		{
+			header: &tar.Header{
+				Name:     "afile",
+				Typeflag: tar.TypeDir,
+			},
+		},
+		// Overwrite symlink to a file with a regular file
+		// the linked file shouldn't be removed
+		{
+			contents: "filereplacingsymlink",
+			header: &tar.Header{
+				Name:     "linktofile",
+				Typeflag: tar.TypeReg,
+				Size:     20,
+			},
+		},
+		// Overwrite symlink to a dir with a regular file
+		// the linked directory and all its contents shouldn't be
+		// removed
+		{
+			contents: "filereplacingsymlink",
+			header: &tar.Header{
+				Name:     "linktodir",
+				Typeflag: tar.TypeReg,
+				Size:     20,
+			},
+		},
+		// folder01 already exists and shouldn't be removed (keeping folder01/file01)
+		{
+			header: &tar.Header{
+				Name:     "folder01",
+				Typeflag: tar.TypeDir,
+				Mode:     int64(0755),
+			},
+		},
+		{
+			contents: "hello",
+			header: &tar.Header{
+				Name: "folder01/file02",
+				Size: 5,
+				Mode: int64(0644),
+			},
+		},
+	}
+	testTarPath, err = newTestTar(entries)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	defer os.Remove(testTarPath)
+	containerTar2, err := os.Open(testTarPath)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	defer containerTar2.Close()
+	err = ExtractTar(containerTar2, tmpdir, true, uid.NewBlankUidRange(), nil)
+
+	expectedFiles := []*fileInfo{
+		&fileInfo{path: "hello.txt", typeflag: tar.TypeReg, size: 8, contents: "newhello"},
+		&fileInfo{path: "linktofile", typeflag: tar.TypeReg, size: 20},
+		&fileInfo{path: "linktodir", typeflag: tar.TypeReg, size: 20},
+		&fileInfo{path: "afolder", typeflag: tar.TypeReg, size: 8},
+		&fileInfo{path: "dirsymlinked", typeflag: tar.TypeDir},
+		&fileInfo{path: "afile", typeflag: tar.TypeDir},
+		&fileInfo{path: "filesymlinked", typeflag: tar.TypeReg, size: 5},
+		&fileInfo{path: "folder01", typeflag: tar.TypeDir},
+		&fileInfo{path: "folder01/file01", typeflag: tar.TypeReg, size: 5},
+		&fileInfo{path: "folder01/file02", typeflag: tar.TypeReg, size: 5},
+	}
+
+	err = checkExpectedFiles(tmpdir, fileInfoSliceToMap(expectedFiles))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestExtractTarTimes(t *testing.T) {
+	if !sys.HasChrootCapability() {
+		t.Skipf("chroot capability not available. Disabling test.")
+	}
+
+	// Do not set ns as tar has second precision
+	time1 := time.Unix(100000, 0)
+	time2 := time.Unix(200000, 0)
+	time3 := time.Unix(300000, 0)
+	entries := []*testTarEntry{
+		{
+			header: &tar.Header{
+				Name:     "folder/",
+				Typeflag: tar.TypeDir,
+				Mode:     int64(0747),
+				ModTime:  time1,
+			},
+		},
+		{
+			contents: "foo",
+			header: &tar.Header{
+				Name:    "folder/foo.txt",
+				Size:    3,
+				ModTime: time2,
+			},
+		},
+		{
+			header: &tar.Header{
+				Name:     "folder/symlink.txt",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "folder/foo.txt",
+				ModTime:  time3,
+			},
+		},
+	}
+
+	testTarPath, err := newTestTar(entries)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	defer os.Remove(testTarPath)
+	containerTar, err := os.Open(testTarPath)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	defer containerTar.Close()
+	tmpdir, err := ioutil.TempDir("", "rkt-temp-dir")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	os.RemoveAll(tmpdir)
+	err = os.MkdirAll(tmpdir, 0755)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	err = ExtractTar(containerTar, tmpdir, false, uid.NewBlankUidRange(), nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	err = checkTime(filepath.Join(tmpdir, "folder/"), time1)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	err = checkTime(filepath.Join(tmpdir, "folder/foo.txt"), time2)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	//Check only (by now) on linux
+	if runtime.GOOS == "linux" {
+		err = checkTime(filepath.Join(tmpdir, "folder/symlink.txt"), time3)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+}
+
+func checkTime(path string, time time.Time) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+
+	if info.ModTime() != time {
+		return fmt.Errorf("%s: info.ModTime: %s, different from expected time: %s", path, info.ModTime(), time)
+	}
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/coreos/rkt/pkg/uid/uid.go
+++ b/Godeps/_workspace/src/github.com/coreos/rkt/pkg/uid/uid.go
@@ -1,0 +1,83 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// For how the uidshift and uidcount are generated please check:
+// http://cgit.freedesktop.org/systemd/systemd/commit/?id=03cfe0d51499e86b1573d1
+
+package uid
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"time"
+)
+
+const DefaultRangeCount = 0x10000
+
+// A UidRange structure used to set uidshift and its range.
+type UidRange struct {
+	Shift uint32
+	Count uint32
+}
+
+func generateUidShift() uint32 {
+	rand.Seed(time.Now().UnixNano())
+	// we force the MSB to 0 because devpts parses the uid,gid options as int
+	// instead of as uint.
+	// http://lxr.free-electrons.com/source/fs/devpts/inode.c?v=4.1#L189
+	// systemd issue: https://github.com/systemd/systemd/issues/956
+	n := rand.Intn(0x7FFF) + 1
+	uidShift := uint32(n << 16)
+
+	return uidShift
+}
+
+func NewBlankUidRange() *UidRange {
+	return &UidRange{
+		Shift: 0,
+		Count: 0}
+}
+
+func (r *UidRange) SetRandomUidRange(uidCount uint32) {
+	uidShift := generateUidShift()
+	r.Shift = uidShift
+	r.Count = uidCount
+}
+
+func (r *UidRange) ShiftRange(uid uint32, gid uint32) (uint32, uint32, error) {
+	if r.Count > 0 && (uid >= r.Count || gid >= r.Count) {
+		return 0, 0, fmt.Errorf("uid %d or gid %d are out of range %d", uid, gid, r.Count)
+	}
+	if math.MaxUint32-r.Shift < uid || math.MaxUint32-r.Shift < gid {
+		return 0, 0, fmt.Errorf("uid or gid are out of range %d after shifting", math.MaxUint32)
+	}
+	return uid + r.Shift, gid + r.Shift, nil
+}
+
+func (r *UidRange) Serialize() []byte {
+	return []byte(fmt.Sprintf("%d:%d", r.Shift, r.Count))
+}
+
+func (r *UidRange) Deserialize(uidRange []byte) error {
+	if len(uidRange) == 0 {
+		return nil
+	}
+	_, err := fmt.Sscanf(string(uidRange), "%d:%d", &r.Shift, &r.Count)
+	if err != nil {
+		return fmt.Errorf("error deserializing uid range: %v", err)
+	}
+
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/syndtr/gocapability/capability/capability.go
+++ b/Godeps/_workspace/src/github.com/syndtr/gocapability/capability/capability.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2013, Suryandaru Triandana <syndtr@gmail.com>
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Package capability provides utilities for manipulating POSIX capabilities.
+package capability
+
+type Capabilities interface {
+	// Get check whether a capability present in the given
+	// capabilities set. The 'which' value should be one of EFFECTIVE,
+	// PERMITTED, INHERITABLE or BOUNDING.
+	Get(which CapType, what Cap) bool
+
+	// Empty check whether all capability bits of the given capabilities
+	// set are zero. The 'which' value should be one of EFFECTIVE,
+	// PERMITTED, INHERITABLE or BOUNDING.
+	Empty(which CapType) bool
+
+	// Full check whether all capability bits of the given capabilities
+	// set are one. The 'which' value should be one of EFFECTIVE,
+	// PERMITTED, INHERITABLE or BOUNDING.
+	Full(which CapType) bool
+
+	// Set sets capabilities of the given capabilities sets. The
+	// 'which' value should be one or combination (OR'ed) of EFFECTIVE,
+	// PERMITTED, INHERITABLE or BOUNDING.
+	Set(which CapType, caps ...Cap)
+
+	// Unset unsets capabilities of the given capabilities sets. The
+	// 'which' value should be one or combination (OR'ed) of EFFECTIVE,
+	// PERMITTED, INHERITABLE or BOUNDING.
+	Unset(which CapType, caps ...Cap)
+
+	// Fill sets all bits of the given capabilities kind to one. The
+	// 'kind' value should be one or combination (OR'ed) of CAPS or
+	// BOUNDS.
+	Fill(kind CapType)
+
+	// Clear sets all bits of the given capabilities kind to zero. The
+	// 'kind' value should be one or combination (OR'ed) of CAPS or
+	// BOUNDS.
+	Clear(kind CapType)
+
+	// String return current capabilities state of the given capabilities
+	// set as string. The 'which' value should be one of EFFECTIVE,
+	// PERMITTED, INHERITABLE or BOUNDING.
+	StringCap(which CapType) string
+
+	// String return current capabilities state as string.
+	String() string
+
+	// Load load actual capabilities value. This will overwrite all
+	// outstanding changes.
+	Load() error
+
+	// Apply apply the capabilities settings, so all changes will take
+	// effect.
+	Apply(kind CapType) error
+}
+
+// NewPid create new initialized Capabilities object for given pid when it
+// is nonzero, or for the current pid if pid is 0
+func NewPid(pid int) (Capabilities, error) {
+	return newPid(pid)
+}
+
+// NewFile create new initialized Capabilities object for given named file.
+func NewFile(name string) (Capabilities, error) {
+	return newFile(name)
+}

--- a/Godeps/_workspace/src/github.com/syndtr/gocapability/capability/capability_linux.go
+++ b/Godeps/_workspace/src/github.com/syndtr/gocapability/capability/capability_linux.go
@@ -1,0 +1,608 @@
+// Copyright (c) 2013, Suryandaru Triandana <syndtr@gmail.com>
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package capability
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"syscall"
+)
+
+var errUnknownVers = errors.New("unknown capability version")
+
+const (
+	linuxCapVer1 = 0x19980330
+	linuxCapVer2 = 0x20071026
+	linuxCapVer3 = 0x20080522
+)
+
+var (
+	capVers    uint32
+	capLastCap Cap
+)
+
+func init() {
+	var hdr capHeader
+	capget(&hdr, nil)
+	capVers = hdr.version
+
+	if initLastCap() == nil {
+		CAP_LAST_CAP = capLastCap
+		if capLastCap > 31 {
+			capUpperMask = (uint32(1) << (uint(capLastCap) - 31)) - 1
+		} else {
+			capUpperMask = 0
+		}
+	}
+}
+
+func initLastCap() error {
+	if capLastCap != 0 {
+		return nil
+	}
+
+	f, err := os.Open("/proc/sys/kernel/cap_last_cap")
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	var b []byte = make([]byte, 11)
+	_, err = f.Read(b)
+	if err != nil {
+		return err
+	}
+
+	fmt.Sscanf(string(b), "%d", &capLastCap)
+
+	return nil
+}
+
+func mkStringCap(c Capabilities, which CapType) (ret string) {
+	for i, first := Cap(0), true; i <= CAP_LAST_CAP; i++ {
+		if !c.Get(which, i) {
+			continue
+		}
+		if first {
+			first = false
+		} else {
+			ret += ", "
+		}
+		ret += i.String()
+	}
+	return
+}
+
+func mkString(c Capabilities, max CapType) (ret string) {
+	ret = "{"
+	for i := CapType(1); i <= max; i <<= 1 {
+		ret += " " + i.String() + "=\""
+		if c.Empty(i) {
+			ret += "empty"
+		} else if c.Full(i) {
+			ret += "full"
+		} else {
+			ret += c.StringCap(i)
+		}
+		ret += "\""
+	}
+	ret += " }"
+	return
+}
+
+func newPid(pid int) (c Capabilities, err error) {
+	switch capVers {
+	case linuxCapVer1:
+		p := new(capsV1)
+		p.hdr.version = capVers
+		p.hdr.pid = pid
+		c = p
+	case linuxCapVer2, linuxCapVer3:
+		p := new(capsV3)
+		p.hdr.version = capVers
+		p.hdr.pid = pid
+		c = p
+	default:
+		err = errUnknownVers
+		return
+	}
+	err = c.Load()
+	if err != nil {
+		c = nil
+	}
+	return
+}
+
+type capsV1 struct {
+	hdr  capHeader
+	data capData
+}
+
+func (c *capsV1) Get(which CapType, what Cap) bool {
+	if what > 32 {
+		return false
+	}
+
+	switch which {
+	case EFFECTIVE:
+		return (1<<uint(what))&c.data.effective != 0
+	case PERMITTED:
+		return (1<<uint(what))&c.data.permitted != 0
+	case INHERITABLE:
+		return (1<<uint(what))&c.data.inheritable != 0
+	}
+
+	return false
+}
+
+func (c *capsV1) getData(which CapType) (ret uint32) {
+	switch which {
+	case EFFECTIVE:
+		ret = c.data.effective
+	case PERMITTED:
+		ret = c.data.permitted
+	case INHERITABLE:
+		ret = c.data.inheritable
+	}
+	return
+}
+
+func (c *capsV1) Empty(which CapType) bool {
+	return c.getData(which) == 0
+}
+
+func (c *capsV1) Full(which CapType) bool {
+	return (c.getData(which) & 0x7fffffff) == 0x7fffffff
+}
+
+func (c *capsV1) Set(which CapType, caps ...Cap) {
+	for _, what := range caps {
+		if what > 32 {
+			continue
+		}
+
+		if which&EFFECTIVE != 0 {
+			c.data.effective |= 1 << uint(what)
+		}
+		if which&PERMITTED != 0 {
+			c.data.permitted |= 1 << uint(what)
+		}
+		if which&INHERITABLE != 0 {
+			c.data.inheritable |= 1 << uint(what)
+		}
+	}
+}
+
+func (c *capsV1) Unset(which CapType, caps ...Cap) {
+	for _, what := range caps {
+		if what > 32 {
+			continue
+		}
+
+		if which&EFFECTIVE != 0 {
+			c.data.effective &= ^(1 << uint(what))
+		}
+		if which&PERMITTED != 0 {
+			c.data.permitted &= ^(1 << uint(what))
+		}
+		if which&INHERITABLE != 0 {
+			c.data.inheritable &= ^(1 << uint(what))
+		}
+	}
+}
+
+func (c *capsV1) Fill(kind CapType) {
+	if kind&CAPS == CAPS {
+		c.data.effective = 0x7fffffff
+		c.data.permitted = 0x7fffffff
+		c.data.inheritable = 0
+	}
+}
+
+func (c *capsV1) Clear(kind CapType) {
+	if kind&CAPS == CAPS {
+		c.data.effective = 0
+		c.data.permitted = 0
+		c.data.inheritable = 0
+	}
+}
+
+func (c *capsV1) StringCap(which CapType) (ret string) {
+	return mkStringCap(c, which)
+}
+
+func (c *capsV1) String() (ret string) {
+	return mkString(c, BOUNDING)
+}
+
+func (c *capsV1) Load() (err error) {
+	return capget(&c.hdr, &c.data)
+}
+
+func (c *capsV1) Apply(kind CapType) error {
+	if kind&CAPS == CAPS {
+		return capset(&c.hdr, &c.data)
+	}
+	return nil
+}
+
+type capsV3 struct {
+	hdr    capHeader
+	data   [2]capData
+	bounds [2]uint32
+}
+
+func (c *capsV3) Get(which CapType, what Cap) bool {
+	var i uint
+	if what > 31 {
+		i = uint(what) >> 5
+		what %= 32
+	}
+
+	switch which {
+	case EFFECTIVE:
+		return (1<<uint(what))&c.data[i].effective != 0
+	case PERMITTED:
+		return (1<<uint(what))&c.data[i].permitted != 0
+	case INHERITABLE:
+		return (1<<uint(what))&c.data[i].inheritable != 0
+	case BOUNDING:
+		return (1<<uint(what))&c.bounds[i] != 0
+	}
+
+	return false
+}
+
+func (c *capsV3) getData(which CapType, dest []uint32) {
+	switch which {
+	case EFFECTIVE:
+		dest[0] = c.data[0].effective
+		dest[1] = c.data[1].effective
+	case PERMITTED:
+		dest[0] = c.data[0].permitted
+		dest[1] = c.data[1].permitted
+	case INHERITABLE:
+		dest[0] = c.data[0].inheritable
+		dest[1] = c.data[1].inheritable
+	case BOUNDING:
+		dest[0] = c.bounds[0]
+		dest[1] = c.bounds[1]
+	}
+}
+
+func (c *capsV3) Empty(which CapType) bool {
+	var data [2]uint32
+	c.getData(which, data[:])
+	return data[0] == 0 && data[1] == 0
+}
+
+func (c *capsV3) Full(which CapType) bool {
+	var data [2]uint32
+	c.getData(which, data[:])
+	if (data[0] & 0xffffffff) != 0xffffffff {
+		return false
+	}
+	return (data[1] & capUpperMask) == capUpperMask
+}
+
+func (c *capsV3) Set(which CapType, caps ...Cap) {
+	for _, what := range caps {
+		var i uint
+		if what > 31 {
+			i = uint(what) >> 5
+			what %= 32
+		}
+
+		if which&EFFECTIVE != 0 {
+			c.data[i].effective |= 1 << uint(what)
+		}
+		if which&PERMITTED != 0 {
+			c.data[i].permitted |= 1 << uint(what)
+		}
+		if which&INHERITABLE != 0 {
+			c.data[i].inheritable |= 1 << uint(what)
+		}
+		if which&BOUNDING != 0 {
+			c.bounds[i] |= 1 << uint(what)
+		}
+	}
+}
+
+func (c *capsV3) Unset(which CapType, caps ...Cap) {
+	for _, what := range caps {
+		var i uint
+		if what > 31 {
+			i = uint(what) >> 5
+			what %= 32
+		}
+
+		if which&EFFECTIVE != 0 {
+			c.data[i].effective &= ^(1 << uint(what))
+		}
+		if which&PERMITTED != 0 {
+			c.data[i].permitted &= ^(1 << uint(what))
+		}
+		if which&INHERITABLE != 0 {
+			c.data[i].inheritable &= ^(1 << uint(what))
+		}
+		if which&BOUNDING != 0 {
+			c.bounds[i] &= ^(1 << uint(what))
+		}
+	}
+}
+
+func (c *capsV3) Fill(kind CapType) {
+	if kind&CAPS == CAPS {
+		c.data[0].effective = 0xffffffff
+		c.data[0].permitted = 0xffffffff
+		c.data[0].inheritable = 0
+		c.data[1].effective = 0xffffffff
+		c.data[1].permitted = 0xffffffff
+		c.data[1].inheritable = 0
+	}
+
+	if kind&BOUNDS == BOUNDS {
+		c.bounds[0] = 0xffffffff
+		c.bounds[1] = 0xffffffff
+	}
+}
+
+func (c *capsV3) Clear(kind CapType) {
+	if kind&CAPS == CAPS {
+		c.data[0].effective = 0
+		c.data[0].permitted = 0
+		c.data[0].inheritable = 0
+		c.data[1].effective = 0
+		c.data[1].permitted = 0
+		c.data[1].inheritable = 0
+	}
+
+	if kind&BOUNDS == BOUNDS {
+		c.bounds[0] = 0
+		c.bounds[1] = 0
+	}
+}
+
+func (c *capsV3) StringCap(which CapType) (ret string) {
+	return mkStringCap(c, which)
+}
+
+func (c *capsV3) String() (ret string) {
+	return mkString(c, BOUNDING)
+}
+
+func (c *capsV3) Load() (err error) {
+	err = capget(&c.hdr, &c.data[0])
+	if err != nil {
+		return
+	}
+
+	var status_path string
+
+	if c.hdr.pid == 0 {
+		status_path = fmt.Sprintf("/proc/self/status")
+	} else {
+		status_path = fmt.Sprintf("/proc/%d/status", c.hdr.pid)
+	}
+
+	f, err := os.Open(status_path)
+	if err != nil {
+		return
+	}
+	b := bufio.NewReader(f)
+	for {
+		line, e := b.ReadString('\n')
+		if e != nil {
+			if e != io.EOF {
+				err = e
+			}
+			break
+		}
+		if strings.HasPrefix(line, "CapB") {
+			fmt.Sscanf(line[4:], "nd:  %08x%08x", &c.bounds[1], &c.bounds[0])
+			break
+		}
+	}
+	f.Close()
+
+	return
+}
+
+func (c *capsV3) Apply(kind CapType) (err error) {
+	if kind&BOUNDS == BOUNDS {
+		var data [2]capData
+		err = capget(&c.hdr, &data[0])
+		if err != nil {
+			return
+		}
+		if (1<<uint(CAP_SETPCAP))&data[0].effective != 0 {
+			for i := Cap(0); i <= CAP_LAST_CAP; i++ {
+				if c.Get(BOUNDING, i) {
+					continue
+				}
+				err = prctl(syscall.PR_CAPBSET_DROP, uintptr(i), 0, 0, 0)
+				if err != nil {
+					// Ignore EINVAL since the capability may not be supported in this system.
+					if errno, ok := err.(syscall.Errno); ok && errno == syscall.EINVAL {
+						err = nil
+						continue
+					}
+					return
+				}
+			}
+		}
+	}
+
+	if kind&CAPS == CAPS {
+		return capset(&c.hdr, &c.data[0])
+	}
+
+	return
+}
+
+func newFile(path string) (c Capabilities, err error) {
+	c = &capsFile{path: path}
+	err = c.Load()
+	if err != nil {
+		c = nil
+	}
+	return
+}
+
+type capsFile struct {
+	path string
+	data vfscapData
+}
+
+func (c *capsFile) Get(which CapType, what Cap) bool {
+	var i uint
+	if what > 31 {
+		if c.data.version == 1 {
+			return false
+		}
+		i = uint(what) >> 5
+		what %= 32
+	}
+
+	switch which {
+	case EFFECTIVE:
+		return (1<<uint(what))&c.data.effective[i] != 0
+	case PERMITTED:
+		return (1<<uint(what))&c.data.data[i].permitted != 0
+	case INHERITABLE:
+		return (1<<uint(what))&c.data.data[i].inheritable != 0
+	}
+
+	return false
+}
+
+func (c *capsFile) getData(which CapType, dest []uint32) {
+	switch which {
+	case EFFECTIVE:
+		dest[0] = c.data.effective[0]
+		dest[1] = c.data.effective[1]
+	case PERMITTED:
+		dest[0] = c.data.data[0].permitted
+		dest[1] = c.data.data[1].permitted
+	case INHERITABLE:
+		dest[0] = c.data.data[0].inheritable
+		dest[1] = c.data.data[1].inheritable
+	}
+}
+
+func (c *capsFile) Empty(which CapType) bool {
+	var data [2]uint32
+	c.getData(which, data[:])
+	return data[0] == 0 && data[1] == 0
+}
+
+func (c *capsFile) Full(which CapType) bool {
+	var data [2]uint32
+	c.getData(which, data[:])
+	if c.data.version == 0 {
+		return (data[0] & 0x7fffffff) == 0x7fffffff
+	}
+	if (data[0] & 0xffffffff) != 0xffffffff {
+		return false
+	}
+	return (data[1] & capUpperMask) == capUpperMask
+}
+
+func (c *capsFile) Set(which CapType, caps ...Cap) {
+	for _, what := range caps {
+		var i uint
+		if what > 31 {
+			if c.data.version == 1 {
+				continue
+			}
+			i = uint(what) >> 5
+			what %= 32
+		}
+
+		if which&EFFECTIVE != 0 {
+			c.data.effective[i] |= 1 << uint(what)
+		}
+		if which&PERMITTED != 0 {
+			c.data.data[i].permitted |= 1 << uint(what)
+		}
+		if which&INHERITABLE != 0 {
+			c.data.data[i].inheritable |= 1 << uint(what)
+		}
+	}
+}
+
+func (c *capsFile) Unset(which CapType, caps ...Cap) {
+	for _, what := range caps {
+		var i uint
+		if what > 31 {
+			if c.data.version == 1 {
+				continue
+			}
+			i = uint(what) >> 5
+			what %= 32
+		}
+
+		if which&EFFECTIVE != 0 {
+			c.data.effective[i] &= ^(1 << uint(what))
+		}
+		if which&PERMITTED != 0 {
+			c.data.data[i].permitted &= ^(1 << uint(what))
+		}
+		if which&INHERITABLE != 0 {
+			c.data.data[i].inheritable &= ^(1 << uint(what))
+		}
+	}
+}
+
+func (c *capsFile) Fill(kind CapType) {
+	if kind&CAPS == CAPS {
+		c.data.effective[0] = 0xffffffff
+		c.data.data[0].permitted = 0xffffffff
+		c.data.data[0].inheritable = 0
+		if c.data.version == 2 {
+			c.data.effective[1] = 0xffffffff
+			c.data.data[1].permitted = 0xffffffff
+			c.data.data[1].inheritable = 0
+		}
+	}
+}
+
+func (c *capsFile) Clear(kind CapType) {
+	if kind&CAPS == CAPS {
+		c.data.effective[0] = 0
+		c.data.data[0].permitted = 0
+		c.data.data[0].inheritable = 0
+		if c.data.version == 2 {
+			c.data.effective[1] = 0
+			c.data.data[1].permitted = 0
+			c.data.data[1].inheritable = 0
+		}
+	}
+}
+
+func (c *capsFile) StringCap(which CapType) (ret string) {
+	return mkStringCap(c, which)
+}
+
+func (c *capsFile) String() (ret string) {
+	return mkString(c, INHERITABLE)
+}
+
+func (c *capsFile) Load() (err error) {
+	return getVfsCap(c.path, &c.data)
+}
+
+func (c *capsFile) Apply(kind CapType) (err error) {
+	if kind&CAPS == CAPS {
+		return setVfsCap(c.path, &c.data)
+	}
+	return
+}

--- a/Godeps/_workspace/src/github.com/syndtr/gocapability/capability/capability_noop.go
+++ b/Godeps/_workspace/src/github.com/syndtr/gocapability/capability/capability_noop.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2013, Suryandaru Triandana <syndtr@gmail.com>
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// +build !linux
+
+package capability
+
+import "errors"
+
+func newPid(pid int) (Capabilities, error) {
+	return nil, errors.New("not supported")
+}
+
+func newFile(path string) (Capabilities, error) {
+	return nil, errors.New("not supported")
+}

--- a/Godeps/_workspace/src/github.com/syndtr/gocapability/capability/capability_test.go
+++ b/Godeps/_workspace/src/github.com/syndtr/gocapability/capability/capability_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2013, Suryandaru Triandana <syndtr@gmail.com>
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package capability
+
+import "testing"
+
+func TestState(t *testing.T) {
+	testEmpty := func(name string, c Capabilities, whats CapType) {
+		for i := CapType(1); i <= BOUNDING; i <<= 1 {
+			if (i&whats) != 0 && !c.Empty(i) {
+				t.Errorf(name+": capabilities set %q wasn't empty", i)
+			}
+		}
+	}
+	testFull := func(name string, c Capabilities, whats CapType) {
+		for i := CapType(1); i <= BOUNDING; i <<= 1 {
+			if (i&whats) != 0 && !c.Full(i) {
+				t.Errorf(name+": capabilities set %q wasn't full", i)
+			}
+		}
+	}
+	testPartial := func(name string, c Capabilities, whats CapType) {
+		for i := CapType(1); i <= BOUNDING; i <<= 1 {
+			if (i&whats) != 0 && (c.Empty(i) || c.Full(i)) {
+				t.Errorf(name+": capabilities set %q wasn't partial", i)
+			}
+		}
+	}
+	testGet := func(name string, c Capabilities, whats CapType, max Cap) {
+		for i := CapType(1); i <= BOUNDING; i <<= 1 {
+			if (i & whats) == 0 {
+				continue
+			}
+			for j := Cap(0); j <= max; j++ {
+				if !c.Get(i, j) {
+					t.Errorf(name+": capability %q wasn't found on %q", j, i)
+				}
+			}
+		}
+	}
+
+	capf := new(capsFile)
+	capf.data.version = 2
+	for _, tc := range []struct {
+		name string
+		c    Capabilities
+		sets CapType
+		max  Cap
+	}{
+		{"v1", new(capsV1), EFFECTIVE | PERMITTED, CAP_AUDIT_CONTROL},
+		{"v3", new(capsV3), EFFECTIVE | PERMITTED | BOUNDING, CAP_LAST_CAP},
+		{"file_v1", new(capsFile), EFFECTIVE | PERMITTED, CAP_AUDIT_CONTROL},
+		{"file_v2", capf, EFFECTIVE | PERMITTED, CAP_LAST_CAP},
+	} {
+		testEmpty(tc.name, tc.c, tc.sets)
+		tc.c.Fill(CAPS | BOUNDS)
+		testFull(tc.name, tc.c, tc.sets)
+		testGet(tc.name, tc.c, tc.sets, tc.max)
+		tc.c.Clear(CAPS | BOUNDS)
+		testEmpty(tc.name, tc.c, tc.sets)
+		for i := CapType(1); i <= BOUNDING; i <<= 1 {
+			for j := Cap(0); j <= CAP_LAST_CAP; j++ {
+				tc.c.Set(i, j)
+			}
+		}
+		testFull(tc.name, tc.c, tc.sets)
+		testGet(tc.name, tc.c, tc.sets, tc.max)
+		for i := CapType(1); i <= BOUNDING; i <<= 1 {
+			for j := Cap(0); j <= CAP_LAST_CAP; j++ {
+				tc.c.Unset(i, j)
+			}
+		}
+		testEmpty(tc.name, tc.c, tc.sets)
+		tc.c.Set(PERMITTED, CAP_CHOWN)
+		testPartial(tc.name, tc.c, PERMITTED)
+		tc.c.Clear(CAPS | BOUNDS)
+		testEmpty(tc.name, tc.c, tc.sets)
+	}
+}

--- a/Godeps/_workspace/src/github.com/syndtr/gocapability/capability/enum.go
+++ b/Godeps/_workspace/src/github.com/syndtr/gocapability/capability/enum.go
@@ -1,0 +1,345 @@
+// Copyright (c) 2013, Suryandaru Triandana <syndtr@gmail.com>
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package capability
+
+type CapType uint
+
+func (c CapType) String() string {
+	switch c {
+	case EFFECTIVE:
+		return "effective"
+	case PERMITTED:
+		return "permitted"
+	case INHERITABLE:
+		return "inheritable"
+	case BOUNDING:
+		return "bounding"
+	case CAPS:
+		return "caps"
+	}
+	return "unknown"
+}
+
+const (
+	EFFECTIVE CapType = 1 << iota
+	PERMITTED
+	INHERITABLE
+	BOUNDING
+
+	CAPS   = EFFECTIVE | PERMITTED | INHERITABLE
+	BOUNDS = BOUNDING
+)
+
+type Cap int
+
+func (c Cap) String() string {
+	switch c {
+	case CAP_CHOWN:
+		return "chown"
+	case CAP_DAC_OVERRIDE:
+		return "dac_override"
+	case CAP_DAC_READ_SEARCH:
+		return "dac_read_search"
+	case CAP_FOWNER:
+		return "fowner"
+	case CAP_FSETID:
+		return "fsetid"
+	case CAP_KILL:
+		return "kill"
+	case CAP_SETGID:
+		return "setgid"
+	case CAP_SETUID:
+		return "setuid"
+	case CAP_SETPCAP:
+		return "setpcap"
+	case CAP_LINUX_IMMUTABLE:
+		return "linux_immutable"
+	case CAP_NET_BIND_SERVICE:
+		return "net_bind_service"
+	case CAP_NET_BROADCAST:
+		return "net_broadcast"
+	case CAP_NET_ADMIN:
+		return "net_admin"
+	case CAP_NET_RAW:
+		return "net_raw"
+	case CAP_IPC_LOCK:
+		return "ipc_lock"
+	case CAP_IPC_OWNER:
+		return "ipc_owner"
+	case CAP_SYS_MODULE:
+		return "sys_module"
+	case CAP_SYS_RAWIO:
+		return "sys_rawio"
+	case CAP_SYS_CHROOT:
+		return "sys_chroot"
+	case CAP_SYS_PTRACE:
+		return "sys_ptrace"
+	case CAP_SYS_PACCT:
+		return "sys_psacct"
+	case CAP_SYS_ADMIN:
+		return "sys_admin"
+	case CAP_SYS_BOOT:
+		return "sys_boot"
+	case CAP_SYS_NICE:
+		return "sys_nice"
+	case CAP_SYS_RESOURCE:
+		return "sys_resource"
+	case CAP_SYS_TIME:
+		return "sys_time"
+	case CAP_SYS_TTY_CONFIG:
+		return "sys_tty_config"
+	case CAP_MKNOD:
+		return "mknod"
+	case CAP_LEASE:
+		return "lease"
+	case CAP_AUDIT_WRITE:
+		return "audit_write"
+	case CAP_AUDIT_CONTROL:
+		return "audit_control"
+	case CAP_SETFCAP:
+		return "setfcap"
+	case CAP_MAC_OVERRIDE:
+		return "mac_override"
+	case CAP_MAC_ADMIN:
+		return "mac_admin"
+	case CAP_SYSLOG:
+		return "syslog"
+	case CAP_WAKE_ALARM:
+		return "wake_alarm"
+	case CAP_BLOCK_SUSPEND:
+		return "block_suspend"
+	case CAP_AUDIT_READ:
+		return "audit_read"
+	}
+	return "unknown"
+}
+
+// POSIX-draft defined capabilities.
+const (
+	// In a system with the [_POSIX_CHOWN_RESTRICTED] option defined, this
+	// overrides the restriction of changing file ownership and group
+	// ownership.
+	CAP_CHOWN = Cap(0)
+
+	// Override all DAC access, including ACL execute access if
+	// [_POSIX_ACL] is defined. Excluding DAC access covered by
+	// CAP_LINUX_IMMUTABLE.
+	CAP_DAC_OVERRIDE = Cap(1)
+
+	// Overrides all DAC restrictions regarding read and search on files
+	// and directories, including ACL restrictions if [_POSIX_ACL] is
+	// defined. Excluding DAC access covered by CAP_LINUX_IMMUTABLE.
+	CAP_DAC_READ_SEARCH = Cap(2)
+
+	// Overrides all restrictions about allowed operations on files, where
+	// file owner ID must be equal to the user ID, except where CAP_FSETID
+	// is applicable. It doesn't override MAC and DAC restrictions.
+	CAP_FOWNER = Cap(3)
+
+	// Overrides the following restrictions that the effective user ID
+	// shall match the file owner ID when setting the S_ISUID and S_ISGID
+	// bits on that file; that the effective group ID (or one of the
+	// supplementary group IDs) shall match the file owner ID when setting
+	// the S_ISGID bit on that file; that the S_ISUID and S_ISGID bits are
+	// cleared on successful return from chown(2) (not implemented).
+	CAP_FSETID = Cap(4)
+
+	// Overrides the restriction that the real or effective user ID of a
+	// process sending a signal must match the real or effective user ID
+	// of the process receiving the signal.
+	CAP_KILL = Cap(5)
+
+	// Allows setgid(2) manipulation
+	// Allows setgroups(2)
+	// Allows forged gids on socket credentials passing.
+	CAP_SETGID = Cap(6)
+
+	// Allows set*uid(2) manipulation (including fsuid).
+	// Allows forged pids on socket credentials passing.
+	CAP_SETUID = Cap(7)
+
+	// Linux-specific capabilities
+
+	// Without VFS support for capabilities:
+	//   Transfer any capability in your permitted set to any pid,
+	//   remove any capability in your permitted set from any pid
+	// With VFS support for capabilities (neither of above, but)
+	//   Add any capability from current's capability bounding set
+	//     to the current process' inheritable set
+	//   Allow taking bits out of capability bounding set
+	//   Allow modification of the securebits for a process
+	CAP_SETPCAP = Cap(8)
+
+	// Allow modification of S_IMMUTABLE and S_APPEND file attributes
+	CAP_LINUX_IMMUTABLE = Cap(9)
+
+	// Allows binding to TCP/UDP sockets below 1024
+	// Allows binding to ATM VCIs below 32
+	CAP_NET_BIND_SERVICE = Cap(10)
+
+	// Allow broadcasting, listen to multicast
+	CAP_NET_BROADCAST = Cap(11)
+
+	// Allow interface configuration
+	// Allow administration of IP firewall, masquerading and accounting
+	// Allow setting debug option on sockets
+	// Allow modification of routing tables
+	// Allow setting arbitrary process / process group ownership on
+	// sockets
+	// Allow binding to any address for transparent proxying (also via NET_RAW)
+	// Allow setting TOS (type of service)
+	// Allow setting promiscuous mode
+	// Allow clearing driver statistics
+	// Allow multicasting
+	// Allow read/write of device-specific registers
+	// Allow activation of ATM control sockets
+	CAP_NET_ADMIN = Cap(12)
+
+	// Allow use of RAW sockets
+	// Allow use of PACKET sockets
+	// Allow binding to any address for transparent proxying (also via NET_ADMIN)
+	CAP_NET_RAW = Cap(13)
+
+	// Allow locking of shared memory segments
+	// Allow mlock and mlockall (which doesn't really have anything to do
+	// with IPC)
+	CAP_IPC_LOCK = Cap(14)
+
+	// Override IPC ownership checks
+	CAP_IPC_OWNER = Cap(15)
+
+	// Insert and remove kernel modules - modify kernel without limit
+	CAP_SYS_MODULE = Cap(16)
+
+	// Allow ioperm/iopl access
+	// Allow sending USB messages to any device via /proc/bus/usb
+	CAP_SYS_RAWIO = Cap(17)
+
+	// Allow use of chroot()
+	CAP_SYS_CHROOT = Cap(18)
+
+	// Allow ptrace() of any process
+	CAP_SYS_PTRACE = Cap(19)
+
+	// Allow configuration of process accounting
+	CAP_SYS_PACCT = Cap(20)
+
+	// Allow configuration of the secure attention key
+	// Allow administration of the random device
+	// Allow examination and configuration of disk quotas
+	// Allow setting the domainname
+	// Allow setting the hostname
+	// Allow calling bdflush()
+	// Allow mount() and umount(), setting up new smb connection
+	// Allow some autofs root ioctls
+	// Allow nfsservctl
+	// Allow VM86_REQUEST_IRQ
+	// Allow to read/write pci config on alpha
+	// Allow irix_prctl on mips (setstacksize)
+	// Allow flushing all cache on m68k (sys_cacheflush)
+	// Allow removing semaphores
+	// Used instead of CAP_CHOWN to "chown" IPC message queues, semaphores
+	// and shared memory
+	// Allow locking/unlocking of shared memory segment
+	// Allow turning swap on/off
+	// Allow forged pids on socket credentials passing
+	// Allow setting readahead and flushing buffers on block devices
+	// Allow setting geometry in floppy driver
+	// Allow turning DMA on/off in xd driver
+	// Allow administration of md devices (mostly the above, but some
+	// extra ioctls)
+	// Allow tuning the ide driver
+	// Allow access to the nvram device
+	// Allow administration of apm_bios, serial and bttv (TV) device
+	// Allow manufacturer commands in isdn CAPI support driver
+	// Allow reading non-standardized portions of pci configuration space
+	// Allow DDI debug ioctl on sbpcd driver
+	// Allow setting up serial ports
+	// Allow sending raw qic-117 commands
+	// Allow enabling/disabling tagged queuing on SCSI controllers and sending
+	// arbitrary SCSI commands
+	// Allow setting encryption key on loopback filesystem
+	// Allow setting zone reclaim policy
+	CAP_SYS_ADMIN = Cap(21)
+
+	// Allow use of reboot()
+	CAP_SYS_BOOT = Cap(22)
+
+	// Allow raising priority and setting priority on other (different
+	// UID) processes
+	// Allow use of FIFO and round-robin (realtime) scheduling on own
+	// processes and setting the scheduling algorithm used by another
+	// process.
+	// Allow setting cpu affinity on other processes
+	CAP_SYS_NICE = Cap(23)
+
+	// Override resource limits. Set resource limits.
+	// Override quota limits.
+	// Override reserved space on ext2 filesystem
+	// Modify data journaling mode on ext3 filesystem (uses journaling
+	// resources)
+	// NOTE: ext2 honors fsuid when checking for resource overrides, so
+	// you can override using fsuid too
+	// Override size restrictions on IPC message queues
+	// Allow more than 64hz interrupts from the real-time clock
+	// Override max number of consoles on console allocation
+	// Override max number of keymaps
+	CAP_SYS_RESOURCE = Cap(24)
+
+	// Allow manipulation of system clock
+	// Allow irix_stime on mips
+	// Allow setting the real-time clock
+	CAP_SYS_TIME = Cap(25)
+
+	// Allow configuration of tty devices
+	// Allow vhangup() of tty
+	CAP_SYS_TTY_CONFIG = Cap(26)
+
+	// Allow the privileged aspects of mknod()
+	CAP_MKNOD = Cap(27)
+
+	// Allow taking of leases on files
+	CAP_LEASE = Cap(28)
+
+	CAP_AUDIT_WRITE   = Cap(29)
+	CAP_AUDIT_CONTROL = Cap(30)
+	CAP_SETFCAP       = Cap(31)
+
+	// Override MAC access.
+	// The base kernel enforces no MAC policy.
+	// An LSM may enforce a MAC policy, and if it does and it chooses
+	// to implement capability based overrides of that policy, this is
+	// the capability it should use to do so.
+	CAP_MAC_OVERRIDE = Cap(32)
+
+	// Allow MAC configuration or state changes.
+	// The base kernel requires no MAC configuration.
+	// An LSM may enforce a MAC policy, and if it does and it chooses
+	// to implement capability based checks on modifications to that
+	// policy or the data required to maintain it, this is the
+	// capability it should use to do so.
+	CAP_MAC_ADMIN = Cap(33)
+
+	// Allow configuring the kernel's syslog (printk behaviour)
+	CAP_SYSLOG = Cap(34)
+
+	// Allow triggering something that will wake the system
+	CAP_WAKE_ALARM = Cap(35)
+
+	// Allow preventing system suspends
+	CAP_BLOCK_SUSPEND = Cap(36)
+
+	// Allow reading audit messages from the kernel
+	CAP_AUDIT_READ = Cap(37)
+)
+
+var (
+	// Highest valid capability of the running kernel.
+	CAP_LAST_CAP = Cap(63)
+
+	capUpperMask = ^uint32(0)
+)

--- a/Godeps/_workspace/src/github.com/syndtr/gocapability/capability/syscall_linux.go
+++ b/Godeps/_workspace/src/github.com/syndtr/gocapability/capability/syscall_linux.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2013, Suryandaru Triandana <syndtr@gmail.com>
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package capability
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+type capHeader struct {
+	version uint32
+	pid     int
+}
+
+type capData struct {
+	effective   uint32
+	permitted   uint32
+	inheritable uint32
+}
+
+func capget(hdr *capHeader, data *capData) (err error) {
+	_, _, e1 := syscall.Syscall(syscall.SYS_CAPGET, uintptr(unsafe.Pointer(hdr)), uintptr(unsafe.Pointer(data)), 0)
+	if e1 != 0 {
+		err = e1
+	}
+	return
+}
+
+func capset(hdr *capHeader, data *capData) (err error) {
+	_, _, e1 := syscall.Syscall(syscall.SYS_CAPSET, uintptr(unsafe.Pointer(hdr)), uintptr(unsafe.Pointer(data)), 0)
+	if e1 != 0 {
+		err = e1
+	}
+	return
+}
+
+func prctl(option int, arg2, arg3, arg4, arg5 uintptr) (err error) {
+	_, _, e1 := syscall.Syscall6(syscall.SYS_PRCTL, uintptr(option), arg2, arg3, arg4, arg5, 0)
+	if e1 != 0 {
+		err = e1
+	}
+	return
+}
+
+const (
+	vfsXattrName = "security.capability"
+
+	vfsCapVerMask = 0xff000000
+	vfsCapVer1    = 0x01000000
+	vfsCapVer2    = 0x02000000
+
+	vfsCapFlagMask      = ^vfsCapVerMask
+	vfsCapFlageffective = 0x000001
+
+	vfscapDataSizeV1 = 4 * (1 + 2*1)
+	vfscapDataSizeV2 = 4 * (1 + 2*2)
+)
+
+type vfscapData struct {
+	magic uint32
+	data  [2]struct {
+		permitted   uint32
+		inheritable uint32
+	}
+	effective [2]uint32
+	version   int8
+}
+
+var (
+	_vfsXattrName *byte
+)
+
+func init() {
+	_vfsXattrName, _ = syscall.BytePtrFromString(vfsXattrName)
+}
+
+func getVfsCap(path string, dest *vfscapData) (err error) {
+	var _p0 *byte
+	_p0, err = syscall.BytePtrFromString(path)
+	if err != nil {
+		return
+	}
+	r0, _, e1 := syscall.Syscall6(syscall.SYS_GETXATTR, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_vfsXattrName)), uintptr(unsafe.Pointer(dest)), vfscapDataSizeV2, 0, 0)
+	if e1 != 0 {
+		err = e1
+	}
+	switch dest.magic & vfsCapVerMask {
+	case vfsCapVer1:
+		dest.version = 1
+		if r0 != vfscapDataSizeV1 {
+			return syscall.EINVAL
+		}
+		dest.data[1].permitted = 0
+		dest.data[1].inheritable = 0
+	case vfsCapVer2:
+		dest.version = 2
+		if r0 != vfscapDataSizeV2 {
+			return syscall.EINVAL
+		}
+	default:
+		return syscall.EINVAL
+	}
+	if dest.magic&vfsCapFlageffective != 0 {
+		dest.effective[0] = dest.data[0].permitted | dest.data[0].inheritable
+		dest.effective[1] = dest.data[1].permitted | dest.data[1].inheritable
+	} else {
+		dest.effective[0] = 0
+		dest.effective[1] = 0
+	}
+	return
+}
+
+func setVfsCap(path string, data *vfscapData) (err error) {
+	var _p0 *byte
+	_p0, err = syscall.BytePtrFromString(path)
+	if err != nil {
+		return
+	}
+	var size uintptr
+	if data.version == 1 {
+		data.magic = vfsCapVer1
+		size = vfscapDataSizeV1
+	} else if data.version == 2 {
+		data.magic = vfsCapVer2
+		if data.effective[0] != 0 || data.effective[1] != 0 {
+			data.magic |= vfsCapFlageffective
+			data.data[0].permitted |= data.effective[0]
+			data.data[1].permitted |= data.effective[1]
+		}
+		size = vfscapDataSizeV2
+	} else {
+		return syscall.EINVAL
+	}
+	_, _, e1 := syscall.Syscall6(syscall.SYS_SETXATTR, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_vfsXattrName)), uintptr(unsafe.Pointer(data)), size, 0, 0)
+	if e1 != 0 {
+		err = e1
+	}
+	return
+}

--- a/acbuild/acbuild.go
+++ b/acbuild/acbuild.go
@@ -23,6 +23,7 @@ import (
 	"text/tabwriter"
 	"text/template"
 
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/coreos/rkt/pkg/multicall"
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/spf13/cobra"
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/spf13/pflag"
 
@@ -144,6 +145,9 @@ func runWrapper(cf func(cmd *cobra.Command, args []string) (exit int)) func(cmd 
 }
 
 func main() {
+	// check if acbuild is executed with a multicall command
+	multicall.MaybeExec()
+
 	cmdAcbuild.SetUsageFunc(usageFunc)
 
 	// Make help just show the usage

--- a/util/files.go
+++ b/util/files.go
@@ -15,11 +15,11 @@
 package util
 
 import (
-	"archive/tar"
-	"fmt"
-	"io"
 	"os"
-	"path"
+	"path/filepath"
+
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/coreos/rkt/pkg/tar"
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/coreos/rkt/pkg/uid"
 )
 
 // RmAndMkdir will remove anything at path if it exists, and then create a
@@ -54,107 +54,15 @@ func Exists(path string) (bool, error) {
 // UnTar will extract the contents at the tar file at tarpath to the directory
 // at dst. If fileMap is set, only files in it will be extracted.
 func UnTar(tarpath, dst string, fileMap map[string]struct{}) error {
+	dst, err := filepath.Abs(dst)
+	if err != nil {
+		return err
+	}
 	tarfile, err := os.Open(tarpath)
 	if err != nil {
 		return err
 	}
 	defer tarfile.Close()
 
-	tr := tar.NewReader(tarfile)
-	var hardlinks []*tar.Header
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
-			// End of tar reached
-			break
-		}
-		if err != nil {
-			return err
-		}
-		switch hdr.Typeflag {
-		case tar.TypeDir:
-			if fileMap != nil {
-				if _, ok := fileMap[hdr.Name]; !ok {
-					continue
-				}
-			}
-			dirpath := path.Join(dst, hdr.Name)
-			ex, err := Exists(dirpath)
-			if err != nil {
-				return err
-			}
-			if ex {
-				err := os.Chmod(dirpath, os.FileMode(hdr.Mode))
-				if err != nil {
-					return err
-				}
-			} else {
-				err := os.MkdirAll(dirpath, os.FileMode(hdr.Mode))
-				if err != nil {
-					return err
-				}
-			}
-		case tar.TypeReg:
-			if fileMap != nil {
-				if _, ok := fileMap[hdr.Name]; !ok {
-					continue
-				}
-			}
-			dir, _ := path.Split(hdr.Name)
-			if dir != "" {
-				err := os.MkdirAll(path.Join(dst, dir), 0755)
-				if err != nil {
-					return err
-				}
-			}
-
-			f, err := os.OpenFile(path.Join(dst, hdr.Name),
-				os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(hdr.Mode))
-			if err != nil {
-				return err
-			}
-			_, err = io.Copy(f, tr)
-			if err != nil {
-				return err
-			}
-			err = f.Close()
-			if err != nil {
-				return err
-			}
-		case tar.TypeSymlink:
-			if fileMap != nil {
-				if _, ok := fileMap[hdr.Name]; !ok {
-					continue
-				}
-			}
-			dir, _ := path.Split(path.Join(dst, hdr.Name))
-			if dir != "" {
-				err := os.MkdirAll(dir, 0755)
-				if err != nil {
-					return err
-				}
-			}
-			err := os.Symlink(hdr.Linkname, path.Join(dst, hdr.Name))
-			if err != nil {
-				return err
-			}
-		case tar.TypeLink:
-			if fileMap != nil {
-				if _, ok := fileMap[hdr.Name]; !ok {
-					continue
-				}
-			}
-			hardlinks = append(hardlinks, hdr)
-		default:
-			return fmt.Errorf("unknown type %c for file in tar: %s",
-				hdr.Typeflag, hdr.Name)
-		}
-	}
-	for _, link := range hardlinks {
-		err := os.Link(link.Linkname, path.Join(dst, link.Name))
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "couldn't create link from %s to %s\n", link.Name, link.Linkname)
-		}
-	}
-	return nil
+	return tar.ExtractTar(tarfile, dst, true, uid.NewBlankUidRange(), fileMap)
 }


### PR DESCRIPTION
The UnTar function failed to handle many edge cases in tar files (like
device nodes), so instead of implementing an untar function in acbuild,
a function from rkt is used.