### PR TITLE
Add script to build acbuild in Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ Follow these steps to do so:
    ./build
    ```
 
+   Or, if you want to build in docker (assuming `$PWD` exists and contains `acbuild/`
+   on your Docker host):
+
+   ```
+   cd acbuild
+   ./build-docker
+   ```
+
 3. A `bin/` directory will be created that contains the `acbuild` tool. To make
    sure your shell can find this executable, append this directory to your
    environment's `$PATH` variable. You can do this in your `.bashrc` or similar

--- a/build-docker
+++ b/build-docker
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker run --rm --tty --interactive --net=host --volume=$PWD:/opt/acbuild --workdir=/opt/acbuild golang:1.5 ${@-./build}


### PR DESCRIPTION
This works well if your running a non-linux host and want to build `acbuild` in a VM that has Docker. It assumes that $PWD points to acbuild wherever your Docker host is running. In boot2docker/coreos-vagrant if you're sharing your homedir, this will be true.