### PR TITLE
*: added context free mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,14 +172,15 @@ dependencies.
 
 `acbuild run` also requires root.
 
+### Context-Free Mode
+
+Calling `begin` and `end` with acbuild to make a single change to an existing
+ACI can be cumbersome, so acbuild provides a context free mode. The
+`--modify=path/to/app.aci` flag can be used to specify an ACI to modify, and
+when provided the current build context will be ignored and the change will be
+applied to the given ACI instead.
+
 ## Planned features
-
-### Context-free mode
-
-There are scenarios in which it is not convenient to need to call `begin` and
-`end`, the most obvious being when a single change is made to an existing ACI.
-A flag will be added to allow every subcommand to be performed on a given ACI,
-instead of looking for a current build in progress.
 
 ### Image signing
 


### PR DESCRIPTION
The `--modify=path/to/app.aci` flag has been added, and when provided acbuild will transparently wrap the call in `begin` and `end`, with the work context being set to a temp directory for the invocation.

As an example:
```
wget https://aci.gonyeo.com/nginx-latest-linux-amd64.aci
acbuild --modify=nginx-linux-latest-amd64.aci annotation add author "Derek Gonyeo"
```

(note this example won't work at the time of writing due to bug with acbuild's UnTar function)