### PR TITLE
Check if overlay fstype is available before loading the module

### DIFF
--- a/lib/run.go
+++ b/lib/run.go
@@ -62,13 +62,15 @@ func Run(acipath, depstore, targetpath, scratchpath, workpath string, cmd []stri
 	}
 
 	if len(man.Dependencies) != 0 {
-		err := util.Exec("modprobe", "overlay")
-		if err != nil {
-			return err
-		}
 		if !supportsOverlay() {
-			return fmt.Errorf(
-				"overlayfs support required for using run with dependencies")
+			err := util.Exec("modprobe", "overlay")
+			if err != nil {
+				return err
+			}
+			if !supportsOverlay() {
+				return fmt.Errorf(
+					"overlayfs support required for using run with dependencies")
+			}
 		}
 	}
 


### PR DESCRIPTION
This change will check if the overlay fstype is already available before
attempting to load the module.

This can help acbuild run better from within a container itself, since often
the kernel modules won't be available to container, but the module will
potentially already be loaded.

@jonboulle @dgonyeo 