### PR TITLE
Update the README example commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ acbuild begin
 acbuild dependency add quay.io/fermayo/ubuntu
 acbuild run -- apt-get update
 acbuild run -- apt-get -y install nginx
+acbuild set-exec /usr/sbin/nginx
+acbuild set-name example.com/ubuntu-nginx
 acbuild end ubuntu-nginx.aci
 ```
 


### PR DESCRIPTION
This updates the example commands in the README to work properly with the exec
command and name now being required before running "acbuild end".

@jonboulle @dgonyeo 