### PR TITLE
godep: update appc/spec dependency

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -7,33 +7,33 @@
 	"Deps": [
 		{
 			"ImportPath": "github.com/appc/spec/aci",
-			"Comment": "v0.7.0-6-ge040d35",
-			"Rev": "e040d35a7bb35a343f04c0f022a669968699d06a"
+			"Comment": "v0.7.1-16-g5a7af19",
+			"Rev": "5a7af198346710d6a432b109b4ddda1c11aad963"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/discovery",
-			"Comment": "v0.7.0-6-ge040d35",
-			"Rev": "e040d35a7bb35a343f04c0f022a669968699d06a"
+			"Comment": "v0.7.1-16-g5a7af19",
+			"Rev": "5a7af198346710d6a432b109b4ddda1c11aad963"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/pkg/acirenderer",
-			"Comment": "v0.7.0-6-ge040d35",
-			"Rev": "e040d35a7bb35a343f04c0f022a669968699d06a"
+			"Comment": "v0.7.1-16-g5a7af19",
+			"Rev": "5a7af198346710d6a432b109b4ddda1c11aad963"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/pkg/device",
-			"Comment": "v0.7.0-6-ge040d35",
-			"Rev": "e040d35a7bb35a343f04c0f022a669968699d06a"
+			"Comment": "v0.7.1-16-g5a7af19",
+			"Rev": "5a7af198346710d6a432b109b4ddda1c11aad963"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/pkg/tarheader",
-			"Comment": "v0.7.0-6-ge040d35",
-			"Rev": "e040d35a7bb35a343f04c0f022a669968699d06a"
+			"Comment": "v0.7.1-16-g5a7af19",
+			"Rev": "5a7af198346710d6a432b109b4ddda1c11aad963"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/schema",
-			"Comment": "v0.7.0-6-ge040d35",
-			"Rev": "e040d35a7bb35a343f04c0f022a669968699d06a"
+			"Comment": "v0.7.1-16-g5a7af19",
+			"Rev": "5a7af198346710d6a432b109b4ddda1c11aad963"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-semver/semver",

--- a/Godeps/_workspace/src/github.com/appc/spec/aci/file_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/aci/file_test.go
@@ -28,7 +28,7 @@ func newTestACI(usedotslash bool) (*os.File, error) {
 		return nil, err
 	}
 
-	manifestBody := `{"acKind":"ImageManifest","acVersion":"0.7.0","name":"example.com/app"}`
+	manifestBody := `{"acKind":"ImageManifest","acVersion":"0.7.1","name":"example.com/app"}`
 
 	gw := gzip.NewWriter(tf)
 	tw := tar.NewWriter(gw)

--- a/Godeps/_workspace/src/github.com/appc/spec/discovery/discovery.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/discovery/discovery.go
@@ -182,9 +182,8 @@ func DiscoverWalk(app App, insecure bool, discoverFn DiscoverWalkFunc) (err erro
 		pre := strings.Join(parts[:end], "/")
 
 		eps, err = doDiscover(pre, app, insecure)
-		derr := discoverFn(pre, eps, err)
-		if derr != nil {
-			return err
+		if derr := discoverFn(pre, eps, err); derr != nil {
+			return derr
 		}
 	}
 

--- a/Godeps/_workspace/src/github.com/appc/spec/discovery/parse_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/discovery/parse_test.go
@@ -52,6 +52,20 @@ func TestNewAppFromString(t *testing.T) {
 
 			false,
 		},
+		{
+			"example.com/app:1.2.3,special=!*'();@&+$/?#[],channel=beta",
+
+			&App{
+				Name: "example.com/app",
+				Labels: map[types.ACIdentifier]string{
+					"version": "1.2.3",
+					"special": "!*'();@&+$/?#[]",
+					"channel": "beta",
+				},
+			},
+
+			false,
+		},
 
 		// bad AC name for app
 		{
@@ -72,6 +86,28 @@ func TestNewAppFromString(t *testing.T) {
 		// multi-value labels
 		{
 			"foo.com/bar,channel=alpha,dog=woof,channel=beta",
+
+			nil,
+			true,
+		},
+		// colon coming after some label instead of being
+		// right after the name
+		{
+			"example.com/app,channel=beta:1.2.3",
+
+			nil,
+			true,
+		},
+		// two colons in string
+		{
+			"example.com/app:3.2.1,channel=beta:1.2.3",
+
+			nil,
+			true,
+		},
+		// two version labels, one implicit, one explicit
+		{
+			"example.com/app:3.2.1,version=1.2.3",
 
 			nil,
 			true,

--- a/Godeps/_workspace/src/github.com/appc/spec/pkg/acirenderer/acirenderer_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/pkg/acirenderer/acirenderer_test.go
@@ -2149,7 +2149,7 @@ func TestEmptyRootFsDir(t *testing.T) {
 			`
 		            {
 		                "acKind": "ImageManifest",
-		                "acVersion": "0.7.0",
+		                "acVersion": "0.7.1",
 		                "name": "example.com/test_empty_rootfs"
 		            }
                         `,
@@ -2175,7 +2175,7 @@ func TestEmptyRootFsDir(t *testing.T) {
 			`
 		            {
 		                "acKind": "ImageManifest",
-		                "acVersion": "0.7.0",
+		                "acVersion": "0.7.1",
 		                "name": "example.com/test_empty_rootfs_pwl",
                                 "pathWhitelist": ["foo"]
 		            }

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/image_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/image_test.go
@@ -20,7 +20,7 @@ func TestEmptyApp(t *testing.T) {
 	imj := `
 		{
 		    "acKind": "ImageManifest",
-		    "acVersion": "0.7.0",
+		    "acVersion": "0.7.1",
 		    "name": "example.com/test"
 		}
 		`

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/lastditch/common_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/lastditch/common_test.go
@@ -1,0 +1,57 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lastditch
+
+import (
+	"fmt"
+	"strings"
+)
+
+// extJ returns a JSON snippet describing an extra field with a given
+// name
+func extJ(name string) string {
+	return fmt.Sprintf(`"%s": [],`, name)
+}
+
+// labsJ returns a labels array JSON snippet with given labels
+func labsJ(labels ...string) string {
+	return fmt.Sprintf("[%s]", strings.Join(labels, ","))
+}
+
+// labsI returns a labels array instance with given labels
+func labsI(labels ...Label) Labels {
+	if labels == nil {
+		return Labels{}
+	}
+	return labels
+}
+
+// labJ returns a label JSON snippet with given name and value
+func labJ(name, value, extra string) string {
+	return fmt.Sprintf(`
+		{
+		    %s
+		    "name": "%s",
+		    "value": "%s"
+		}`, extra, name, value)
+}
+
+// labI returns a label instance with given name and value
+func labI(name, value string) Label {
+	return Label{
+		Name:  name,
+		Value: value,
+	}
+}

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/lastditch/image_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/lastditch/image_test.go
@@ -15,35 +15,61 @@
 package lastditch
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
-
-	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 )
 
-func TestImageManifestWithInvalidName(t *testing.T) {
-	invalidName := "example.com/test!"
-	imj := `
+func TestInvalidImageManifest(t *testing.T) {
+	tests := []struct {
+		desc     string
+		json     string
+		expected ImageManifest
+	}{
 		{
-		    "acKind": "ImageManifest",
-		    "acVersion": "0.7.0",
-		    "name": "` + invalidName + `"
+			desc:     "Check an empty image manifest",
+			json:     imgJ("", labsJ(), ""),
+			expected: imgI("", labsI()),
+		},
+		{
+			desc:     "Check an image manifest with an empty label",
+			json:     imgJ("example.com/test!", labsJ(labJ("", "", "")), ""),
+			expected: imgI("example.com/test!", labsI(labI("", ""))),
+		},
+		{
+			desc:     "Check an image manifest with an invalid name",
+			json:     imgJ("example.com/test!", labsJ(), ""),
+			expected: imgI("example.com/test!", labsI()),
+		},
+		{
+			desc:     "Check an image manifest with labels with invalid names",
+			json:     imgJ("im", labsJ(labJ("!n1", "v1", ""), labJ("N2~", "v2", "")), ""),
+			expected: imgI("im", labsI(labI("!n1", "v1"), labI("N2~", "v2"))),
+		},
+		{
+			desc:     "Check an image manifest with duplicated labels",
+			json:     imgJ("im", labsJ(labJ("n1", "v1", ""), labJ("n1", "v2", "")), ""),
+			expected: imgI("im", labsI(labI("n1", "v1"), labI("n1", "v2"))),
+		},
+		{
+			desc:     "Check an image manifest with some extra fields",
+			json:     imgJ("im", labsJ(), extJ("stuff")),
+			expected: imgI("im", labsI()),
+		},
+		{
+			desc:     "Check an image manifest with a label containing some extra fields",
+			json:     imgJ("im", labsJ(labJ("n1", "v1", extJ("clutter"))), extJ("stuff")),
+			expected: imgI("im", labsI(labI("n1", "v1"))),
+		},
+	}
+	for _, tt := range tests {
+		got := ImageManifest{}
+		if err := got.UnmarshalJSON([]byte(tt.json)); err != nil {
+			t.Errorf("%s: unexpected error during unmarshalling image manifest: %v", tt.desc, err)
 		}
-		`
-	if types.ValidACIdentifier.MatchString(invalidName) {
-		t.Fatalf("%q is an unexpectedly valid name", invalidName)
-	}
-	expected := ImageManifest{
-		ACKind:    "ImageManifest",
-		ACVersion: "0.7.0",
-		Name:      invalidName,
-	}
-	im := ImageManifest{}
-	if err := im.UnmarshalJSON([]byte(imj)); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if !reflect.DeepEqual(im, expected) {
-		t.Errorf("did not get expected image manifest, got: %+v, expected: %+v", im, expected)
+		if !reflect.DeepEqual(tt.expected, got) {
+			t.Errorf("%s: did not get expected image manifest, got:\n  %#v\nexpected:\n  %#v", tt.desc, got, tt.expected)
+		}
 	}
 }
 
@@ -51,7 +77,7 @@ func TestBogusImageManifest(t *testing.T) {
 	bogus := []string{`
 		{
 		    "acKind": "Bogus",
-		    "acVersion": "0.7.0",
+		    "acVersion": "0.7.1",
 		}
 		`, `
 		<html>
@@ -66,5 +92,27 @@ func TestBogusImageManifest(t *testing.T) {
 		if im.UnmarshalJSON([]byte(str)) == nil {
 			t.Errorf("bogus image manifest unmarshalled successfully: %s", str)
 		}
+	}
+}
+
+// imgJ returns an image manifest JSON with given name and labels
+func imgJ(name, labels, extra string) string {
+	return fmt.Sprintf(`
+		{
+		    %s
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.7.1",
+		    "name": "%s",
+		    "labels": %s
+		}`, extra, name, labels)
+}
+
+// imgI returns an image manifest instance with given name and labels
+func imgI(name string, labels Labels) ImageManifest {
+	return ImageManifest{
+		ACVersion: "0.7.1",
+		ACKind:    "ImageManifest",
+		Name:      name,
+		Labels:    labels,
 	}
 }

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/lastditch/labels.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/lastditch/labels.go
@@ -16,30 +16,23 @@ package lastditch
 
 import (
 	"encoding/json"
-
-	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/schema"
-	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 )
 
-type ImageManifest struct {
-	ACVersion string `json:"acVersion"`
-	ACKind    string `json:"acKind"`
-	Name      string `json:"name"`
-	Labels    Labels `json:"labels,omitempty"`
-}
+type Labels []Label
 
 // a type just to avoid a recursion during unmarshalling
-type imageManifest ImageManifest
+type labels Labels
 
-func (im *ImageManifest) UnmarshalJSON(data []byte) error {
-	i := imageManifest(*im)
-	err := json.Unmarshal(data, &i)
-	if err != nil {
+type Label struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+func (l *Labels) UnmarshalJSON(data []byte) error {
+	var jl labels
+	if err := json.Unmarshal(data, &jl); err != nil {
 		return err
 	}
-	if i.ACKind != string(schema.ImageManifestKind) {
-		return types.InvalidACKindError(schema.ImageManifestKind)
-	}
-	*im = ImageManifest(i)
+	*l = Labels(jl)
 	return nil
 }

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/lastditch/pod.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/lastditch/pod.go
@@ -30,13 +30,14 @@ type PodManifest struct {
 type AppList []RuntimeApp
 
 type RuntimeApp struct {
-	Name  string `json:"name"`
-	Image Image  `json:"image"`
+	Name  string       `json:"name"`
+	Image RuntimeImage `json:"image"`
 }
 
-type Image struct {
-	Name string `json:"name"`
-	ID   string `json:"id"`
+type RuntimeImage struct {
+	Name   string `json:"name"`
+	ID     string `json:"id"`
+	Labels Labels `json:"labels,omitempty"`
 }
 
 // a type just to avoid a recursion during unmarshalling

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/lastditch/pod_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/lastditch/pod_test.go
@@ -17,14 +17,11 @@ package lastditch
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 )
 
 func TestInvalidPodManifest(t *testing.T) {
-	// empty image JSON
-	eImgJ := "{}"
-	// empty image instance
-	eImgI := imgI("", "")
 	tests := []struct {
 		desc     string
 		json     string
@@ -32,38 +29,68 @@ func TestInvalidPodManifest(t *testing.T) {
 	}{
 		{
 			desc:     "Check an empty pod manifest",
-			json:     podJ("", ""),
-			expected: podI(),
+			json:     podJ(appsJ(), ""),
+			expected: podI(appsI()),
+		},
+		{
+			desc:     "Check a pod manifest with an empty app",
+			json:     podJ(appsJ(appJ("", rImgJ("i", "id", labsJ(), ""), "")), ""),
+			expected: podI(appsI(appI("", rImgI("i", "id", labsI())))),
+		},
+		{
+			desc:     "Check a pod manifest with an app based on an empty image",
+			json:     podJ(appsJ(appJ("a", rImgJ("", "", labsJ(), ""), "")), ""),
+			expected: podI(appsI(appI("a", rImgI("", "", labsI())))),
+		},
+		{
+			desc:     "Check a pod manifest with an app based on an image containing an empty label",
+			json:     podJ(appsJ(appJ("a", rImgJ("", "", labsJ(labJ("", "", "")), ""), "")), ""),
+			expected: podI(appsI(appI("a", rImgI("", "", labsI(labI("", "")))))),
 		},
 		{
 			desc:     "Check a pod manifest with an invalid app name",
-			json:     podJ(appJ("!", eImgJ, ""), ""),
-			expected: podI(appI("!", eImgI)),
+			json:     podJ(appsJ(appJ("!", rImgJ("i", "id", labsJ(), ""), "")), ""),
+			expected: podI(appsI(appI("!", rImgI("i", "id", labsI())))),
 		},
 		{
 			desc:     "Check a pod manifest with duplicated app names",
-			json:     podJ(appJ("a", eImgJ, "")+","+appJ("a", eImgJ, ""), ""),
-			expected: podI(appI("a", eImgI), appI("a", eImgI)),
+			json:     podJ(appsJ(appJ("a", rImgJ("i", "id", labsJ(), ""), ""), appJ("a", rImgJ("", "", labsJ(), ""), "")), ""),
+			expected: podI(appsI(appI("a", rImgI("i", "id", labsI())), appI("a", rImgI("", "", labsI())))),
 		},
 		{
 			desc:     "Check a pod manifest with an invalid image name and ID",
-			json:     podJ(appJ("?", imgJ("!!!", "&&&", ""), ""), ""),
-			expected: podI(appI("?", imgI("!!!", "&&&"))),
+			json:     podJ(appsJ(appJ("?", rImgJ("!!!", "&&&", labsJ(), ""), "")), ""),
+			expected: podI(appsI(appI("?", rImgI("!!!", "&&&", labsI())))),
 		},
 		{
-			desc:     "Check if we ignore extra fields in a pod",
-			json:     podJ("", `"ports": [],`),
-			expected: podI(),
+			desc:     "Check a pod manifest with an app based on an image containing labels with invalid names",
+			json:     podJ(appsJ(appJ("a", rImgJ("i", "id", labsJ(labJ("!n1", "v1", ""), labJ("N2~", "v2", "")), ""), "")), ""),
+			expected: podI(appsI(appI("a", rImgI("i", "id", labsI(labI("!n1", "v1"), labI("N2~", "v2")))))),
 		},
 		{
-			desc:     "Check if we ignore extra fields in an app",
-			json:     podJ(appJ("a", eImgJ, `"mounts": [],`), `"ports": [],`),
-			expected: podI(appI("a", eImgI)),
+			desc:     "Check a pod manifest with an app based on an image containing repeated labels",
+			json:     podJ(appsJ(appJ("a", rImgJ("i", "id", labsJ(labJ("n1", "v1", ""), labJ("n1", "v2", "")), ""), "")), ""),
+			expected: podI(appsI(appI("a", rImgI("i", "id", labsI(labI("n1", "v1"), labI("n1", "v2")))))),
 		},
 		{
-			desc:     "Check if we ignore extra fields in an image",
-			json:     podJ(appJ("a", imgJ("i", "id", `"labels": [],`), `"mounts": [],`), `"ports": [],`),
-			expected: podI(appI("a", imgI("i", "id"))),
+			desc:     "Check a pod manifest with some extra fields",
+			json:     podJ(appsJ(), extJ("goblins")),
+			expected: podI(appsI()),
+		},
+		{
+			desc:     "Check a pod manifest with an app containing some extra fields",
+			json:     podJ(appsJ(appJ("a", rImgJ("i", "id", labsJ(), ""), extJ("trolls"))), extJ("goblins")),
+			expected: podI(appsI(appI("a", rImgI("i", "id", labsI())))),
+		},
+		{
+			desc:     "Check a pod manifest with an app based on an image containing some extra fields",
+			json:     podJ(appsJ(appJ("a", rImgJ("i", "id", labsJ(), extJ("stuff")), extJ("trolls"))), extJ("goblins")),
+			expected: podI(appsI(appI("a", rImgI("i", "id", labsI())))),
+		},
+		{
+			desc:     "Check a pod manifest with an app based on an image containing labels with some extra fields",
+			json:     podJ(appsJ(appJ("a", rImgJ("i", "id", labsJ(labJ("n", "v", extJ("color"))), extJ("stuff")), extJ("trolls"))), extJ("goblins")),
+			expected: podI(appsI(appI("a", rImgI("i", "id", labsI(labI("n", "v")))))),
 		},
 	}
 	for _, tt := range tests {
@@ -72,7 +99,7 @@ func TestInvalidPodManifest(t *testing.T) {
 			t.Errorf("%s: unexpected error during unmarshalling pod manifest: %v", tt.desc, err)
 		}
 		if !reflect.DeepEqual(tt.expected, got) {
-			t.Errorf("%s: did not get expected pod manifest, got: %+v, expected: %+v", tt.desc, got, tt.expected)
+			t.Errorf("%s: did not get expected pod manifest, got:\n  %#v\nexpected:\n  %#v", tt.desc, got, tt.expected)
 		}
 	}
 }
@@ -82,7 +109,7 @@ func TestBogusPodManifest(t *testing.T) {
 		`
 			{
 			    "acKind": "Bogus",
-			    "acVersion": "0.7.0",
+			    "acVersion": "0.7.1",
 			}
 			`,
 		`
@@ -107,21 +134,31 @@ func podJ(apps, extra string) string {
 		{
 		    %s
 		    "acKind": "PodManifest",
-		    "acVersion": "0.7.0",
-		    "apps": [%s]
+		    "acVersion": "0.7.1",
+		    "apps": %s
 		}`, extra, apps)
 }
 
 // podI returns a pod manifest instance with given apps
-func podI(apps ...RuntimeApp) PodManifest {
-	if apps == nil {
-		apps = AppList{}
-	}
+func podI(apps AppList) PodManifest {
 	return PodManifest{
-		ACVersion: "0.7.0",
+		ACVersion: "0.7.1",
 		ACKind:    "PodManifest",
 		Apps:      apps,
 	}
+}
+
+// appsJ returns an applist JSON snippet with given apps
+func appsJ(apps ...string) string {
+	return fmt.Sprintf("[%s]", strings.Join(apps, ","))
+}
+
+// appsI returns an applist instance with given apps
+func appsI(apps ...RuntimeApp) AppList {
+	if apps == nil {
+		return AppList{}
+	}
+	return apps
 }
 
 // appJ returns an app JSON snippet with given name and image
@@ -135,27 +172,31 @@ func appJ(name, image, extra string) string {
 }
 
 // appI returns an app instance with given name and image
-func appI(name string, image Image) RuntimeApp {
+func appI(name string, image RuntimeImage) RuntimeApp {
 	return RuntimeApp{
 		Name:  name,
 		Image: image,
 	}
 }
 
-// imgJ returns an image JSON snippet with given name and id
-func imgJ(name, id, extra string) string {
+// rImgJ returns a runtime image JSON snippet with given name, id and
+// labels
+func rImgJ(name, id, labels, extra string) string {
 	return fmt.Sprintf(`
 		{
 		    %s
 		    "name": "%s",
-		    "id": "%s"
-		}`, extra, name, id)
+		    "id": "%s",
+		    "labels": %s
+		}`, extra, name, id, labels)
 }
 
-// imgI returns an image instance with given name and id
-func imgI(name, id string) Image {
-	return Image{
-		Name: name,
-		ID:   id,
+// rImgI returns a runtime image instance with given name, id and
+// labels
+func rImgI(name, id string, labels Labels) RuntimeImage {
+	return RuntimeImage{
+		Name:   name,
+		ID:     id,
+		Labels: labels,
 	}
 }

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/app.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/app.go
@@ -22,16 +22,16 @@ import (
 )
 
 type App struct {
-	Exec                Exec           `json:"exec"`
-	EventHandlers       []EventHandler `json:"eventHandlers,omitempty"`
-	User                string         `json:"user"`
-	Group               string         `json:"group"`
-	SupplementaryGroups []int          `json:"supplementaryGroups,omitempty"`
-	WorkingDirectory    string         `json:"workingDirectory,omitempty"`
-	Environment         Environment    `json:"environment,omitempty"`
-	MountPoints         []MountPoint   `json:"mountPoints,omitempty"`
-	Ports               []Port         `json:"ports,omitempty"`
-	Isolators           Isolators      `json:"isolators,omitempty"`
+	Exec              Exec           `json:"exec"`
+	EventHandlers     []EventHandler `json:"eventHandlers,omitempty"`
+	User              string         `json:"user"`
+	Group             string         `json:"group"`
+	SupplementaryGIDs []int          `json:"supplementaryGIDs,omitempty"`
+	WorkingDirectory  string         `json:"workingDirectory,omitempty"`
+	Environment       Environment    `json:"environment,omitempty"`
+	MountPoints       []MountPoint   `json:"mountPoints,omitempty"`
+	Ports             []Port         `json:"ports,omitempty"`
+	Isolators         Isolators      `json:"isolators,omitempty"`
 }
 
 // app is a model to facilitate extra validation during the
@@ -67,13 +67,13 @@ func (a *App) assertValid() error {
 		return err
 	}
 	if a.User == "" {
-		return errors.New(`User is required`)
+		return errors.New(`user is required`)
 	}
 	if a.Group == "" {
-		return errors.New(`Group is required`)
+		return errors.New(`group is required`)
 	}
 	if !path.IsAbs(a.WorkingDirectory) && a.WorkingDirectory != "" {
-		return errors.New("WorkingDirectory must be an absolute path")
+		return errors.New("workingDirectory must be an absolute path")
 	}
 	eh := make(map[string]bool)
 	for _, e := range a.EventHandlers {

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/app_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/app_test.go
@@ -55,28 +55,48 @@ func TestAppValid(t *testing.T) {
 }
 
 func TestAppExecInvalid(t *testing.T) {
-	tests := []App{
-		App{
-			Exec: nil,
+	tests := []struct {
+		app   App
+		valid bool
+	}{
+		{
+			App{
+				Exec:  nil,
+				User:  "0",
+				Group: "0",
+			},
+			true,
 		},
-		App{
-			Exec:  []string{},
-			User:  "0",
-			Group: "0",
+		{
+			App{
+				Exec:  []string{},
+				User:  "0",
+				Group: "0",
+			},
+			true,
 		},
-		App{
-			Exec:  []string{"app"},
-			User:  "0",
-			Group: "0",
+		{
+			App{
+				Exec:  []string{"app"},
+				User:  "0",
+				Group: "0",
+			},
+			false,
 		},
-		App{
-			Exec:  []string{"bin/app", "arg1"},
-			User:  "0",
-			Group: "0",
+		{
+			App{
+				Exec:  []string{"bin/app", "arg1"},
+				User:  "0",
+				Group: "0",
+			},
+			false,
 		},
 	}
 	for i, tt := range tests {
-		if err := tt.assertValid(); err == nil {
+		err := tt.app.assertValid()
+		if err != nil && tt.valid {
+			t.Errorf("#%d: err == %v, want nil", i, err)
+		} else if err == nil && !tt.valid {
 			t.Errorf("#%d: err == nil, want non-nil", i)
 		}
 	}

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/exec.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/exec.go
@@ -25,11 +25,8 @@ type Exec []string
 type exec Exec
 
 func (e Exec) assertValid() error {
-	if len(e) < 1 {
-		return errors.New(`Exec cannot be empty`)
-	}
-	if !filepath.IsAbs(e[0]) {
-		return errors.New(`Exec[0] must be absolute path`)
+	if len(e) > 0 && !filepath.IsAbs(e[0]) {
+		return errors.New(`exec[0] must be absolute path`)
 	}
 	return nil
 }

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/exec_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/exec_test.go
@@ -31,7 +31,6 @@ func TestExecValid(t *testing.T) {
 
 func TestExecInvalid(t *testing.T) {
 	tests := []Exec{
-		Exec{},
 		Exec{"app"},
 	}
 	for i, tt := range tests {

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/isolator_linux_specific.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/isolator_linux_specific.go
@@ -27,11 +27,13 @@ const (
 var LinuxIsolatorNames = make(map[ACIdentifier]struct{})
 
 func init() {
-	AddIsolatorName(LinuxCapabilitiesRetainSetName, LinuxIsolatorNames)
-	AddIsolatorName(LinuxCapabilitiesRevokeSetName, LinuxIsolatorNames)
-
-	AddIsolatorValueConstructor(LinuxCapabilitiesRetainSetName, NewLinuxCapabilitiesRetainSet)
-	AddIsolatorValueConstructor(LinuxCapabilitiesRevokeSetName, NewLinuxCapabilitiesRevokeSet)
+	for name, con := range map[ACIdentifier]IsolatorValueConstructor{
+		LinuxCapabilitiesRevokeSetName: func() IsolatorValue { return &LinuxCapabilitiesRevokeSet{} },
+		LinuxCapabilitiesRetainSetName: func() IsolatorValue { return &LinuxCapabilitiesRetainSet{} },
+	} {
+		AddIsolatorName(name, LinuxIsolatorNames)
+		AddIsolatorValueConstructor(name, con)
+	}
 }
 
 type LinuxCapabilitiesSet interface {
@@ -40,6 +42,7 @@ type LinuxCapabilitiesSet interface {
 }
 
 type LinuxCapability string
+
 type linuxCapabilitiesSetValue struct {
 	Set []LinuxCapability `json:"set"`
 }
@@ -71,18 +74,70 @@ func (l linuxCapabilitiesSetBase) Set() []LinuxCapability {
 	return l.val.Set
 }
 
-func NewLinuxCapabilitiesRetainSet() IsolatorValue {
-	return &LinuxCapabilitiesRetainSet{}
-}
-
 type LinuxCapabilitiesRetainSet struct {
 	linuxCapabilitiesSetBase
 }
 
-func NewLinuxCapabilitiesRevokeSet() IsolatorValue {
-	return &LinuxCapabilitiesRevokeSet{}
+func NewLinuxCapabilitiesRetainSet(caps ...string) (*LinuxCapabilitiesRetainSet, error) {
+	l := LinuxCapabilitiesRetainSet{
+		linuxCapabilitiesSetBase{
+			linuxCapabilitiesSetValue{
+				make([]LinuxCapability, len(caps)),
+			},
+		},
+	}
+	for i, c := range caps {
+		l.linuxCapabilitiesSetBase.val.Set[i] = LinuxCapability(c)
+	}
+	if err := l.AssertValid(); err != nil {
+		return nil, err
+	}
+	return &l, nil
+}
+
+func (l LinuxCapabilitiesRetainSet) AsIsolator() Isolator {
+	b, err := json.Marshal(l)
+	if err != nil {
+		panic(err)
+	}
+	rm := json.RawMessage(b)
+	return Isolator{
+		Name:     LinuxCapabilitiesRetainSetName,
+		ValueRaw: &rm,
+		value:    &l,
+	}
 }
 
 type LinuxCapabilitiesRevokeSet struct {
 	linuxCapabilitiesSetBase
+}
+
+func NewLinuxCapabilitiesRevokeSet(caps ...string) (*LinuxCapabilitiesRevokeSet, error) {
+	l := LinuxCapabilitiesRevokeSet{
+		linuxCapabilitiesSetBase{
+			linuxCapabilitiesSetValue{
+				make([]LinuxCapability, len(caps)),
+			},
+		},
+	}
+	for i, c := range caps {
+		l.linuxCapabilitiesSetBase.val.Set[i] = LinuxCapability(c)
+	}
+	if err := l.AssertValid(); err != nil {
+		return nil, err
+	}
+	return &l, nil
+}
+
+func (l LinuxCapabilitiesRevokeSet) AsIsolator() Isolator {
+	b, err := json.Marshal(l)
+	if err != nil {
+		panic(err)
+	}
+	rm := json.RawMessage(b)
+	return Isolator{
+		Name:     LinuxCapabilitiesRevokeSetName,
+		ValueRaw: &rm,
+		value:    &l,
+	}
 }

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/isolator_linux_specific_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/isolator_linux_specific_test.go
@@ -1,0 +1,96 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewLinuxCapabilitiesRetainSet(t *testing.T) {
+	tests := []struct {
+		in []string
+
+		wset []LinuxCapability
+		werr bool
+	}{
+		{
+			[]string{},
+			nil,
+			true,
+		},
+		{
+			[]string{"CAP_ADMIN"},
+			[]LinuxCapability{"CAP_ADMIN"},
+			false,
+		},
+		{
+			[]string{"CAP_AUDIT_READ", "CAP_KILL"},
+			[]LinuxCapability{"CAP_AUDIT_READ", "CAP_KILL"},
+			false,
+		},
+	}
+	for i, tt := range tests {
+		c, err := NewLinuxCapabilitiesRetainSet(tt.in...)
+		if tt.werr {
+			if err == nil {
+				t.Errorf("#%d: did not get expected error", i)
+			}
+			continue
+		}
+		if gset := c.Set(); !reflect.DeepEqual(gset, tt.wset) {
+			t.Errorf("#%d: got %#v, want %#v", i, gset, tt.wset)
+		}
+	}
+
+}
+
+func TestNewLinuxCapabilitiesRevokeSet(t *testing.T) {
+	tests := []struct {
+		in []string
+
+		wset []LinuxCapability
+		werr bool
+	}{
+		{
+			[]string{},
+			[]LinuxCapability{},
+			true,
+		},
+		{
+			[]string{"CAP_AUDIT_WRITE"},
+			[]LinuxCapability{"CAP_AUDIT_WRITE"},
+			false,
+		},
+		{
+			[]string{"CAP_SYS_ADMIN", "CAP_CHOWN"},
+			[]LinuxCapability{"CAP_SYS_ADMIN", "CAP_CHOWN"},
+			false,
+		},
+	}
+	for i, tt := range tests {
+		c, err := NewLinuxCapabilitiesRevokeSet(tt.in...)
+		if tt.werr {
+			if err == nil {
+				t.Errorf("#%d: did not get expected error", i)
+			}
+			continue
+		}
+		if gset := c.Set(); !reflect.DeepEqual(gset, tt.wset) {
+			t.Errorf("#%d: got %#v, want %#v", i, gset, tt.wset)
+		}
+	}
+
+}

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/isolator_resources.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/isolator_resources.go
@@ -17,6 +17,7 @@ package types
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/appc/acbuild/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/resource"
 )
@@ -38,33 +39,16 @@ const (
 )
 
 func init() {
-	AddIsolatorName(ResourceBlockBandwidthName, ResourceIsolatorNames)
-	AddIsolatorName(ResourceBlockIOPSName, ResourceIsolatorNames)
-	AddIsolatorName(ResourceCPUName, ResourceIsolatorNames)
-	AddIsolatorName(ResourceMemoryName, ResourceIsolatorNames)
-	AddIsolatorName(ResourceNetworkBandwidthName, ResourceIsolatorNames)
-
-	AddIsolatorValueConstructor(ResourceBlockBandwidthName, NewResourceBlockBandwidth)
-	AddIsolatorValueConstructor(ResourceBlockIOPSName, NewResourceBlockIOPS)
-	AddIsolatorValueConstructor(ResourceCPUName, NewResourceCPU)
-	AddIsolatorValueConstructor(ResourceMemoryName, NewResourceMemory)
-	AddIsolatorValueConstructor(ResourceNetworkBandwidthName, NewResourceNetworkBandwidth)
-}
-
-func NewResourceBlockBandwidth() IsolatorValue {
-	return &ResourceBlockBandwidth{}
-}
-func NewResourceBlockIOPS() IsolatorValue {
-	return &ResourceBlockIOPS{}
-}
-func NewResourceCPU() IsolatorValue {
-	return &ResourceCPU{}
-}
-func NewResourceNetworkBandwidth() IsolatorValue {
-	return &ResourceNetworkBandwidth{}
-}
-func NewResourceMemory() IsolatorValue {
-	return &ResourceMemory{}
+	for name, con := range map[ACIdentifier]IsolatorValueConstructor{
+		ResourceBlockBandwidthName:   func() IsolatorValue { return &ResourceBlockBandwidth{} },
+		ResourceBlockIOPSName:        func() IsolatorValue { return &ResourceBlockIOPS{} },
+		ResourceCPUName:              func() IsolatorValue { return &ResourceCPU{} },
+		ResourceMemoryName:           func() IsolatorValue { return &ResourceMemory{} },
+		ResourceNetworkBandwidthName: func() IsolatorValue { return &ResourceNetworkBandwidth{} },
+	} {
+		AddIsolatorName(name, ResourceIsolatorNames)
+		AddIsolatorValueConstructor(name, con)
+	}
 }
 
 type Resource interface {
@@ -133,6 +117,10 @@ type ResourceCPU struct {
 	ResourceBase
 }
 
+func (r ResourceCPU) String() string {
+	return fmt.Sprintf("ResourceCPU(request=%s, limit=%s)", r.Request(), r.Limit())
+}
+
 func (r ResourceCPU) AssertValid() error {
 	if r.Default() != false {
 		return ErrDefaultTrue
@@ -140,8 +128,36 @@ func (r ResourceCPU) AssertValid() error {
 	return nil
 }
 
+func NewResourceCPUIsolator(request, limit string) (*ResourceCPU, error) {
+	req, err := resource.ParseQuantity(request)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing request: %v", err)
+	}
+	lim, err := resource.ParseQuantity(limit)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing limit: %v", err)
+	}
+	res := &ResourceCPU{
+		ResourceBase{
+			resourceValue{
+				Request: req,
+				Limit:   lim,
+			},
+		},
+	}
+	if err := res.AssertValid(); err != nil {
+		// should never happen
+		return nil, err
+	}
+	return res, nil
+}
+
 type ResourceMemory struct {
 	ResourceBase
+}
+
+func (r ResourceMemory) String() string {
+	return fmt.Sprintf("ResourceMemory(request=%s, limit=%s)", r.Request(), r.Limit())
 }
 
 func (r ResourceMemory) AssertValid() error {
@@ -149,6 +165,30 @@ func (r ResourceMemory) AssertValid() error {
 		return ErrDefaultTrue
 	}
 	return nil
+}
+
+func NewResourceMemoryIsolator(request, limit string) (*ResourceMemory, error) {
+	req, err := resource.ParseQuantity(request)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing request: %v", err)
+	}
+	lim, err := resource.ParseQuantity(limit)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing limit: %v", err)
+	}
+	res := &ResourceMemory{
+		ResourceBase{
+			resourceValue{
+				Request: req,
+				Limit:   lim,
+			},
+		},
+	}
+	if err := res.AssertValid(); err != nil {
+		// should never happen
+		return nil, err
+	}
+	return res, nil
 }
 
 type ResourceNetworkBandwidth struct {

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/isolator_resources_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/isolator_resources_test.go
@@ -1,0 +1,125 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/appc/acbuild/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/resource"
+)
+
+func mustQuantity(s string) *resource.Quantity {
+	q := resource.MustParse(s)
+	return &q
+}
+
+func TestResourceMemoryIsolator(t *testing.T) {
+	tests := []struct {
+		inreq string
+		inlim string
+
+		wres *ResourceMemory
+		werr bool
+	}{
+		{
+			"100M",
+			"200M",
+
+			&ResourceMemory{
+				ResourceBase{
+					resourceValue{
+						Request: mustQuantity("100M"),
+						Limit:   mustQuantity("200M"),
+					},
+				},
+			},
+			false,
+		},
+	}
+	for i, tt := range tests {
+		gres, err := NewResourceMemoryIsolator(tt.inreq, tt.inlim)
+		if gerr := err != nil; gerr != tt.werr {
+			t.Errorf("#%d: want werr=%t, got %t (err=%v)", i, tt.werr, gerr, err)
+		}
+		if !reflect.DeepEqual(tt.wres, gres) {
+			t.Errorf("#%d: want %s, got %s", i, tt.wres, gres)
+		}
+	}
+}
+
+func TestResourceCPUIsolator(t *testing.T) {
+	tests := []struct {
+		inreq string
+		inlim string
+
+		wres *ResourceCPU
+		werr bool
+	}{
+		// empty is not valid
+		{
+			"",
+			"2",
+
+			nil,
+			true,
+		},
+		// garbage value
+		{
+			"1",
+			"such garbage",
+
+			nil,
+			true,
+		},
+		{
+			"1",
+			"2",
+
+			&ResourceCPU{
+				ResourceBase{
+					resourceValue{
+						Request: mustQuantity("1"),
+						Limit:   mustQuantity("2"),
+					},
+				},
+			},
+			false,
+		},
+		{
+			"345",
+			"6",
+
+			&ResourceCPU{
+				ResourceBase{
+					resourceValue{
+						Request: mustQuantity("345"),
+						Limit:   mustQuantity("6"),
+					},
+				},
+			},
+			false,
+		},
+	}
+	for i, tt := range tests {
+		gres, err := NewResourceCPUIsolator(tt.inreq, tt.inlim)
+		if gerr := err != nil; gerr != tt.werr {
+			t.Errorf("#%d: want werr=%t, got %t (err=%v)", i, tt.werr, gerr, err)
+		}
+		if !reflect.DeepEqual(tt.wres, gres) {
+			t.Errorf("#%d: want %s, got %s", i, tt.wres, gres)
+		}
+	}
+}

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/version.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/version.go
@@ -22,7 +22,7 @@ const (
 	// version represents the canonical version of the appc spec and tooling.
 	// For now, the schema and tooling is coupled with the spec itself, so
 	// this must be kept in sync with the VERSION file in the root of the repo.
-	version string = "0.7.0+git"
+	version string = "0.7.1+git"
 )
 
 var (


### PR DESCRIPTION
acbuild was using an older version of the appc/spec, which was causing
an issue with GetACI in registry/registry.go when the exec command of
a dependency wasn't set.