### PR TITLE
begin: add support for fetching remote ACIs to start from

### DIFF
--- a/acbuild/acbuild.go
+++ b/acbuild/acbuild.go
@@ -143,8 +143,25 @@ func runWrapper(cf func(cmd *cobra.Command, args []string) (exit int)) func(cmd 
 		}
 		defer os.Remove(buildpath)
 
+		finfo, err := os.Stat(aciToModify)
+		switch {
+		case os.IsNotExist(err):
+			stderr("ACI doesn't appear to exist: %s.", aciToModify)
+			cmdExitCode = 1
+			return
+		case err != nil:
+			stderr("Error accessing ACI to modify: %v.", err)
+			cmdExitCode = 1
+			return
+		case finfo.IsDir():
+			stderr("ACI to modify is a directory: %s.", aciToModify)
+			cmdExitCode = 1
+			return
+		}
+
 		a := lib.NewACBuild(buildpath, debug)
-		err = a.Begin(aciToModify)
+
+		err = a.Begin(aciToModify, false)
 		if err != nil {
 			stderr("%v", err)
 			cmdExitCode = 1

--- a/acbuild/begin.go
+++ b/acbuild/begin.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	cmdBegin = &cobra.Command{
-		Use:     "begin [START_ACI_PATH]",
+		Use:     "begin [START_ACI]",
 		Short:   "Start a new build",
 		Long:    "Begins a new build. By default operations will be performed on top of an empty image, but a start image can be provided",
 		Example: "acbuild begin",
@@ -30,6 +30,7 @@ var (
 
 func init() {
 	cmdAcbuild.AddCommand(cmdBegin)
+	cmdBegin.Flags().BoolVar(&insecure, "insecure", false, "Allows fetching dependencies over an unencrypted connection")
 }
 
 func runBegin(cmd *cobra.Command, args []string) (exit int) {
@@ -48,9 +49,9 @@ func runBegin(cmd *cobra.Command, args []string) (exit int) {
 
 	var err error
 	if len(args) == 0 {
-		err = newACBuild().Begin("")
+		err = newACBuild().Begin("", insecure)
 	} else {
-		err = newACBuild().Begin(args[0])
+		err = newACBuild().Begin(args[0], insecure)
 	}
 
 	if err != nil {


### PR DESCRIPTION
With this change if the ACI provided to begin does not exist on the
filesystem, meta discovery is performed to locate and download the ACI.