### PR TITLE
*: refactored library functions, added struct with common fields

### DIFF
--- a/acbuild/annotation.go
+++ b/acbuild/annotation.go
@@ -16,8 +16,6 @@ package main
 
 import (
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/spf13/cobra"
-
-	"github.com/appc/acbuild/lib"
 )
 
 var (
@@ -59,23 +57,11 @@ func runAddAnno(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	lockfile, err := getLock()
-	if err != nil {
-		stderr("annotation add: %v", err)
-		return 1
-	}
-	defer func() {
-		if err := releaseLock(lockfile); err != nil {
-			stderr("annotation add: %v", err)
-			exit = 1
-		}
-	}()
-
 	if debug {
 		stderr("Adding annotation %q=%q", args[0], args[1])
 	}
 
-	err = lib.AddAnnotation(tmpacipath(), args[0], args[1])
+	err := newACBuild().AddAnnotation(args[0], args[1])
 
 	if err != nil {
 		stderr("annotation add: %v", err)
@@ -95,23 +81,11 @@ func runRmAnno(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	lockfile, err := getLock()
-	if err != nil {
-		stderr("annotation remove: %v", err)
-		return 1
-	}
-	defer func() {
-		if err := releaseLock(lockfile); err != nil {
-			stderr("annotation remove: %v", err)
-			exit = 1
-		}
-	}()
-
 	if debug {
 		stderr("Removing annotation %q", args[0])
 	}
 
-	err = lib.RemoveAnnotation(tmpacipath(), args[0])
+	err := newACBuild().RemoveAnnotation(args[0])
 
 	if err != nil {
 		stderr("annotation remove: %v", err)

--- a/acbuild/begin.go
+++ b/acbuild/begin.go
@@ -15,13 +15,7 @@
 package main
 
 import (
-	"os"
-	"path"
-
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/spf13/cobra"
-
-	"github.com/appc/acbuild/lib"
-	"github.com/appc/acbuild/util"
 )
 
 var (
@@ -44,34 +38,6 @@ func runBegin(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	ex, err := util.Exists(path.Join(contextpath, workprefix))
-	if err != nil {
-		stderr("begin: %v", err)
-		return 1
-	}
-	if ex {
-		stderr("begin: build already in progress in this working dir")
-		return 1
-	}
-
-	err = os.MkdirAll(path.Join(contextpath, workprefix), 0755)
-	if err != nil {
-		stderr("begin: %v", err)
-		return 1
-	}
-
-	lockfile, err := getLock()
-	if err != nil {
-		stderr("begin: %v", err)
-		return 1
-	}
-	defer func() {
-		if err := releaseLock(lockfile); err != nil {
-			stderr("begin: %v", err)
-			exit = 1
-		}
-	}()
-
 	if debug {
 		if len(args) == 0 {
 			stderr("Beginning build with an empty ACI")
@@ -80,10 +46,11 @@ func runBegin(cmd *cobra.Command, args []string) (exit int) {
 		}
 	}
 
+	var err error
 	if len(args) == 0 {
-		err = lib.Begin(tmpacipath(), "")
+		err = newACBuild().Begin("")
 	} else {
-		err = lib.Begin(tmpacipath(), args[0])
+		err = newACBuild().Begin(args[0])
 	}
 
 	if err != nil {

--- a/acbuild/copy.go
+++ b/acbuild/copy.go
@@ -16,8 +16,6 @@ package main
 
 import (
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/spf13/cobra"
-
-	"github.com/appc/acbuild/lib"
 )
 
 var (
@@ -43,23 +41,11 @@ func runCopy(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	lockfile, err := getLock()
-	if err != nil {
-		stderr("copy: %v", err)
-		return 1
-	}
-	defer func() {
-		if err := releaseLock(lockfile); err != nil {
-			stderr("copy: %v", err)
-			exit = 1
-		}
-	}()
-
 	if debug {
 		stderr("Copying host:%s to aci:%s", args[0], args[1])
 	}
 
-	err = lib.Copy(tmpacipath(), args[0], args[1])
+	err := newACBuild().Copy(args[0], args[1])
 
 	if err != nil {
 		stderr("copy: %v", err)

--- a/acbuild/dependency.go
+++ b/acbuild/dependency.go
@@ -20,8 +20,6 @@ import (
 
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/spf13/cobra"
-
-	"github.com/appc/acbuild/lib"
 )
 
 var (
@@ -70,23 +68,11 @@ func runAddDep(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	lockfile, err := getLock()
-	if err != nil {
-		stderr("dependency add: %v", err)
-		return 1
-	}
-	defer func() {
-		if err := releaseLock(lockfile); err != nil {
-			stderr("dependency add: %v", err)
-			exit = 1
-		}
-	}()
-
 	if debug {
 		stderr("Adding dependency %q", args[0])
 	}
 
-	err = lib.AddDependency(tmpacipath(), args[0], imageId,
+	err := newACBuild().AddDependency(args[0], imageId,
 		types.Labels(labels), size)
 
 	if err != nil {
@@ -107,23 +93,11 @@ func runRmDep(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	lockfile, err := getLock()
-	if err != nil {
-		stderr("dependency remove: %v", err)
-		return 1
-	}
-	defer func() {
-		if err := releaseLock(lockfile); err != nil {
-			stderr("dependency remove: %v", err)
-			exit = 1
-		}
-	}()
-
 	if debug {
 		stderr("Removing dependency %q", args[0])
 	}
 
-	err = lib.RemoveDependency(tmpacipath(), args[0])
+	err := newACBuild().RemoveDependency(args[0])
 
 	if err != nil {
 		stderr("dependency remove: %v", err)

--- a/acbuild/end.go
+++ b/acbuild/end.go
@@ -15,12 +15,7 @@
 package main
 
 import (
-	"os"
-	"path"
-
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/spf13/cobra"
-
-	"github.com/appc/acbuild/lib"
 )
 
 var (
@@ -43,27 +38,14 @@ func runEnd(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	lockfile, err := getLock()
-	if err != nil {
-		stderr("end: %v", err)
-		return 1
-	}
-	// Lock will be released when lib.End deletes the folder containing the
-	// lockfile.
-
 	if debug {
 		stderr("Ending the build")
 	}
 
-	err = lib.End(path.Join(contextpath, workprefix))
+	err := newACBuild().End()
 
 	if err != nil {
 		stderr("end: %v", err)
-		// In the event of an error the lockfile may have not been removed, so
-		// let's release the lock now
-		if err := releaseLock(lockfile); !os.IsNotExist(err) {
-			stderr("end: %v", err)
-		}
 		return 1
 	}
 

--- a/acbuild/environment.go
+++ b/acbuild/environment.go
@@ -16,8 +16,6 @@ package main
 
 import (
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/spf13/cobra"
-
-	"github.com/appc/acbuild/lib"
 )
 
 var (
@@ -59,23 +57,11 @@ func runAddEnv(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	lockfile, err := getLock()
-	if err != nil {
-		stderr("environment add: %v", err)
-		return 1
-	}
-	defer func() {
-		if err := releaseLock(lockfile); err != nil {
-			stderr("environment add: %v", err)
-			exit = 1
-		}
-	}()
-
 	if debug {
 		stderr("Adding environment variable %q=%q", args[0], args[1])
 	}
 
-	err = lib.AddEnv(tmpacipath(), args[0], args[1])
+	err := newACBuild().AddEnv(args[0], args[1])
 
 	if err != nil {
 		stderr("environment add: %v", err)
@@ -95,23 +81,11 @@ func runRemoveEnv(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	lockfile, err := getLock()
-	if err != nil {
-		stderr("environment remove: %v", err)
-		return 1
-	}
-	defer func() {
-		if err := releaseLock(lockfile); err != nil {
-			stderr("environment remove: %v", err)
-			exit = 1
-		}
-	}()
-
 	if debug {
 		stderr("Removing environment variable %q", args[0])
 	}
 
-	err = lib.RemoveEnv(tmpacipath(), args[0])
+	err := newACBuild().RemoveEnv(args[0])
 
 	if err != nil {
 		stderr("environment remove: %v", err)

--- a/acbuild/label.go
+++ b/acbuild/label.go
@@ -16,8 +16,6 @@ package main
 
 import (
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/spf13/cobra"
-
-	"github.com/appc/acbuild/lib"
 )
 
 var (
@@ -58,23 +56,11 @@ func runAddLabel(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	lockfile, err := getLock()
-	if err != nil {
-		stderr("label add: %v", err)
-		return 1
-	}
-	defer func() {
-		if err := releaseLock(lockfile); err != nil {
-			stderr("label add: %v", err)
-			exit = 1
-		}
-	}()
-
 	if debug {
 		stderr("Adding label %q=%q", args[0], args[1])
 	}
 
-	err = lib.AddLabel(tmpacipath(), args[0], args[1])
+	err := newACBuild().AddLabel(args[0], args[1])
 
 	if err != nil {
 		stderr("label add: %v", err)
@@ -94,23 +80,11 @@ func runRemoveLabel(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	lockfile, err := getLock()
-	if err != nil {
-		stderr("label remove: %v", err)
-		return 1
-	}
-	defer func() {
-		if err := releaseLock(lockfile); err != nil {
-			stderr("label remove: %v", err)
-			exit = 1
-		}
-	}()
-
 	if debug {
 		stderr("Removing label %q", args[0])
 	}
 
-	err = lib.RemoveLabel(tmpacipath(), args[0])
+	err := newACBuild().RemoveLabel(args[0])
 
 	if err != nil {
 		stderr("label remove: %v", err)

--- a/acbuild/mount.go
+++ b/acbuild/mount.go
@@ -16,8 +16,6 @@ package main
 
 import (
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/spf13/cobra"
-
-	"github.com/appc/acbuild/lib"
 )
 
 var (
@@ -61,18 +59,6 @@ func runAddMount(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	lockfile, err := getLock()
-	if err != nil {
-		stderr("mount add: %v", err)
-		return 1
-	}
-	defer func() {
-		if err := releaseLock(lockfile); err != nil {
-			stderr("mount add: %v", err)
-			exit = 1
-		}
-	}()
-
 	if debug {
 		if readOnly {
 			stderr("Adding read only mount point %q=%q", args[0], args[1])
@@ -81,7 +67,7 @@ func runAddMount(cmd *cobra.Command, args []string) (exit int) {
 		}
 	}
 
-	err = lib.AddMount(tmpacipath(), args[0], args[1], readOnly)
+	err := newACBuild().AddMount(args[0], args[1], readOnly)
 
 	if err != nil {
 		stderr("mount add: %v", err)
@@ -101,23 +87,11 @@ func runRmMount(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	lockfile, err := getLock()
-	if err != nil {
-		stderr("mount remove: %v", err)
-		return 1
-	}
-	defer func() {
-		if err := releaseLock(lockfile); err != nil {
-			stderr("mount remove: %v", err)
-			exit = 1
-		}
-	}()
-
 	if debug {
 		stderr("Removing mount point %q", args[0])
 	}
 
-	err = lib.RemoveMount(tmpacipath(), args[0])
+	err := newACBuild().RemoveMount(args[0])
 
 	if err != nil {
 		stderr("mount remove: %v", err)

--- a/acbuild/port.go
+++ b/acbuild/port.go
@@ -18,8 +18,6 @@ import (
 	"strconv"
 
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/spf13/cobra"
-
-	"github.com/appc/acbuild/lib"
 )
 
 var (
@@ -70,23 +68,11 @@ func runAddPort(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	lockfile, err := getLock()
-	if err != nil {
-		stderr("port add: %v", err)
-		return 1
-	}
-	defer func() {
-		if err := releaseLock(lockfile); err != nil {
-			stderr("port add: %v", err)
-			exit = 1
-		}
-	}()
-
 	if debug {
 		stderr("Adding port %q=%q", args[0], args[1])
 	}
 
-	err = lib.AddPort(tmpacipath(), args[0], args[1], uint(port), count, socketActivated)
+	err = newACBuild().AddPort(args[0], args[1], uint(port), count, socketActivated)
 
 	if err != nil {
 		stderr("port add: %v", err)
@@ -106,23 +92,11 @@ func runRmPort(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	lockfile, err := getLock()
-	if err != nil {
-		stderr("port remove: %v", err)
-		return 1
-	}
-	defer func() {
-		if err := releaseLock(lockfile); err != nil {
-			stderr("port remove: %v", err)
-			exit = 1
-		}
-	}()
-
 	if debug {
 		stderr("Removing port %q", args[0])
 	}
 
-	err = lib.RemovePort(tmpacipath(), args[0])
+	err := newACBuild().RemovePort(args[0])
 
 	if err != nil {
 		stderr("port remove: %v", err)

--- a/acbuild/run.go
+++ b/acbuild/run.go
@@ -16,8 +16,6 @@ package main
 
 import (
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/spf13/cobra"
-
-	"github.com/appc/acbuild/lib"
 )
 
 var (
@@ -43,23 +41,11 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	lockfile, err := getLock()
-	if err != nil {
-		stderr("run: %v", err)
-		return 1
-	}
-	defer func() {
-		if err := releaseLock(lockfile); err != nil {
-			stderr("run: %v", err)
-			exit = 1
-		}
-	}()
-
 	if debug {
 		stderr("Running: %v", args)
 	}
 
-	err = lib.Run(tmpacipath(), depstorepath(), targetpath(), scratchpath(), workpath(), args, insecure)
+	err := newACBuild().Run(args, insecure)
 
 	if err != nil {
 		stderr("run: %v", err)

--- a/acbuild/set-exec.go
+++ b/acbuild/set-exec.go
@@ -16,8 +16,6 @@ package main
 
 import (
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/spf13/cobra"
-
-	"github.com/appc/acbuild/lib"
 )
 
 var (
@@ -40,23 +38,11 @@ func runSetExec(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	lockfile, err := getLock()
-	if err != nil {
-		stderr("set-exec: %v", err)
-		return 1
-	}
-	defer func() {
-		if err := releaseLock(lockfile); err != nil {
-			stderr("set-exec: %v", err)
-			exit = 1
-		}
-	}()
-
 	if debug {
 		stderr("Setting exec command %v", args)
 	}
 
-	err = lib.SetExec(tmpacipath(), args)
+	err := newACBuild().SetExec(args)
 
 	if err != nil {
 		stderr("set-exec: %v", err)

--- a/acbuild/set-group.go
+++ b/acbuild/set-group.go
@@ -16,8 +16,6 @@ package main
 
 import (
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/spf13/cobra"
-
-	"github.com/appc/acbuild/lib"
 )
 
 var (
@@ -44,23 +42,11 @@ func runSetGroup(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	lockfile, err := getLock()
-	if err != nil {
-		stderr("set-group: %v", err)
-		return 1
-	}
-	defer func() {
-		if err := releaseLock(lockfile); err != nil {
-			stderr("set-group: %v", err)
-			exit = 1
-		}
-	}()
-
 	if debug {
 		stderr("Setting group to %s", args[0])
 	}
 
-	err = lib.SetGroup(tmpacipath(), args[0])
+	err := newACBuild().SetGroup(args[0])
 
 	if err != nil {
 		stderr("set-group: %v", err)

--- a/acbuild/set-name.go
+++ b/acbuild/set-name.go
@@ -16,8 +16,6 @@ package main
 
 import (
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/spf13/cobra"
-
-	"github.com/appc/acbuild/lib"
 )
 
 var (
@@ -44,23 +42,11 @@ func runSetName(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	lockfile, err := getLock()
-	if err != nil {
-		stderr("set-name: %v", err)
-		return 1
-	}
-	defer func() {
-		if err := releaseLock(lockfile); err != nil {
-			stderr("set-name: %v", err)
-			exit = 1
-		}
-	}()
-
 	if debug {
 		stderr("Setting name of ACI to %s", args[0])
 	}
 
-	err = lib.SetName(tmpacipath(), args[0])
+	err := newACBuild().SetName(args[0])
 
 	if err != nil {
 		stderr("set-name: %v", err)

--- a/acbuild/set-user.go
+++ b/acbuild/set-user.go
@@ -16,8 +16,6 @@ package main
 
 import (
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/spf13/cobra"
-
-	"github.com/appc/acbuild/lib"
 )
 
 var (
@@ -44,23 +42,11 @@ func runSetUser(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	lockfile, err := getLock()
-	if err != nil {
-		stderr("set-user: %v", err)
-		return 1
-	}
-	defer func() {
-		if err := releaseLock(lockfile); err != nil {
-			stderr("set-user: %v", err)
-			exit = 1
-		}
-	}()
-
 	if debug {
 		stderr("Setting user to %s", args[0])
 	}
 
-	err = lib.SetUser(tmpacipath(), args[0])
+	err := newACBuild().SetUser(args[0])
 
 	if err != nil {
 		stderr("set-user: %v", err)

--- a/acbuild/write.go
+++ b/acbuild/write.go
@@ -16,8 +16,6 @@ package main
 
 import (
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/spf13/cobra"
-
-	"github.com/appc/acbuild/lib"
 )
 
 var (
@@ -45,23 +43,11 @@ func runWrite(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	lockfile, err := getLock()
-	if err != nil {
-		stderr("write: %v", err)
-		return 1
-	}
-	defer func() {
-		if err := releaseLock(lockfile); err != nil {
-			stderr("write: %v", err)
-			exit = 1
-		}
-	}()
-
 	if debug {
 		stderr("Writing ACI to %s", args[0])
 	}
 
-	err = lib.Write(tmpacipath(), args[0], overwrite, sign, args[1:])
+	err := newACBuild().Write(args[0], overwrite, sign, args[1:])
 
 	if err != nil {
 		stderr("write: %v", err)

--- a/lib/common.go
+++ b/lib/common.go
@@ -1,0 +1,110 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lib
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"syscall"
+
+	"github.com/appc/acbuild/util"
+)
+
+const defaultWorkPath = ".acbuild"
+
+// ACBuild contains all the information for a current build. Once an ACBuild
+// has been created, the functions available on it will perform different
+// actions in the build, like updating a dependency or writing a finished ACI.
+type ACBuild struct {
+	ContextPath          string
+	LockPath             string
+	CurrentACIPath       string
+	DepStoreTarPath      string
+	DepStoreExpandedPath string
+	OverlayTargetPath    string
+	OverlayWorkPath      string
+	Debug                bool
+
+	lockFile *os.File
+}
+
+// NewACBuild returns a new ACBuild struct with sane defaults for all of the
+// different paths
+func NewACBuild(cwd string, debug bool) *ACBuild {
+	return &ACBuild{
+		ContextPath:          path.Join(cwd, defaultWorkPath),
+		LockPath:             path.Join(cwd, defaultWorkPath, "lock"),
+		CurrentACIPath:       path.Join(cwd, defaultWorkPath, "currentaci"),
+		DepStoreTarPath:      path.Join(cwd, defaultWorkPath, "depstore-tar"),
+		DepStoreExpandedPath: path.Join(cwd, defaultWorkPath, "depstore-expanded"),
+		OverlayTargetPath:    path.Join(cwd, defaultWorkPath, "target"),
+		OverlayWorkPath:      path.Join(cwd, defaultWorkPath, "work"),
+		Debug:                debug,
+	}
+}
+
+func (a *ACBuild) lock() error {
+	ex, err := util.Exists(a.ContextPath)
+	if err != nil {
+		return err
+	}
+	if !ex {
+		return fmt.Errorf("build not in progress in this working dir - try \"acbuild begin\"")
+	}
+
+	if a.lockFile != nil {
+		return fmt.Errorf("lock already held by this ACBuild")
+	}
+
+	a.lockFile, err = os.OpenFile(a.LockPath, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return err
+	}
+
+	err = syscall.Flock(int(a.lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err != nil {
+		if err == syscall.EWOULDBLOCK {
+			return fmt.Errorf("lock already held - is another acbuild running in this working dir?")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (a *ACBuild) unlock() error {
+	if a.lockFile == nil {
+		return fmt.Errorf("lock isn't held by this ACBuild")
+	}
+
+	err := syscall.Flock(int(a.lockFile.Fd()), syscall.LOCK_UN)
+	if err != nil {
+		return err
+	}
+
+	err = a.lockFile.Close()
+	if err != nil {
+		return err
+	}
+	a.lockFile = nil
+
+	err = os.Remove(a.LockPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/lib/copy.go
+++ b/lib/copy.go
@@ -24,9 +24,18 @@ import (
 )
 
 // Copy will copy the directory/file at from to the path to inside the untarred
-// ACI at acipath.
-func Copy(acipath, from, to string) error {
-	target := path.Join(acipath, aci.RootfsDir, to)
+// ACI at a.CurrentACIPath.
+func (a *ACBuild) Copy(from, to string) (err error) {
+	if err = a.lock(); err != nil {
+		return err
+	}
+	defer func() {
+		if err1 := a.unlock(); err == nil {
+			err = err1
+		}
+	}()
+
+	target := path.Join(a.CurrentACIPath, aci.RootfsDir, to)
 
 	dir, _ := path.Split(target)
 	if dir != "" {

--- a/lib/end.go
+++ b/lib/end.go
@@ -21,10 +21,10 @@ import (
 	"github.com/appc/acbuild/util"
 )
 
-// End will stop the current build, given the path that the build resources
-// are stored at. An error will be returned if no build is in progress.
-func End(contextpath string) error {
-	ok, err := util.Exists(contextpath)
+// End will stop the current build. An error will be returned if no build is in
+// progress.
+func (a *ACBuild) End() error {
+	ok, err := util.Exists(a.ContextPath)
 	if err != nil {
 		return err
 	}
@@ -32,7 +32,11 @@ func End(contextpath string) error {
 		return fmt.Errorf("build not in progress")
 	}
 
-	err = os.RemoveAll(contextpath)
+	if err = a.lock(); err != nil {
+		return err
+	}
+
+	err = os.RemoveAll(a.ContextPath)
 	if err != nil {
 		return err
 	}

--- a/lib/env.go
+++ b/lib/env.go
@@ -37,20 +37,38 @@ func removeFromEnv(name string) func(*schema.ImageManifest) {
 }
 
 // AddEnv will add an environment variable with the given name and value to the
-// untarred ACI stored at acipath. If the environment variable already exists
-// its value will be updated to the new value.
-func AddEnv(acipath, name, value string) error {
+// untarred ACI stored at a.CurrentACIPath. If the environment variable already
+// exists its value will be updated to the new value.
+func (a *ACBuild) AddEnv(name, value string) (err error) {
+	if err = a.lock(); err != nil {
+		return err
+	}
+	defer func() {
+		if err1 := a.unlock(); err == nil {
+			err = err1
+		}
+	}()
+
 	fn := func(s *schema.ImageManifest) {
 		if s.App == nil {
 			s.App = &types.App{}
 		}
 		s.App.Environment.Set(name, value)
 	}
-	return util.ModifyManifest(fn, acipath)
+	return util.ModifyManifest(fn, a.CurrentACIPath)
 }
 
 // RemoveEnv will remove the environment variable with the given name from the
-// untarred ACI stored at acipath
-func RemoveEnv(acipath, name string) error {
-	return util.ModifyManifest(removeFromEnv(name), acipath)
+// untarred ACI stored at a.CurrentACIPath.
+func (a *ACBuild) RemoveEnv(name string) (err error) {
+	if err = a.lock(); err != nil {
+		return err
+	}
+	defer func() {
+		if err1 := a.unlock(); err == nil {
+			err = err1
+		}
+	}()
+
+	return util.ModifyManifest(removeFromEnv(name), a.CurrentACIPath)
 }

--- a/lib/label.go
+++ b/lib/label.go
@@ -34,9 +34,18 @@ func removeLabelFromMan(name types.ACIdentifier) func(*schema.ImageManifest) {
 }
 
 // AddLabel will add a label with the given name and value to the untarred ACI
-// stored at acipath. If the label already exists its value will be updated to
+// stored at a.CurrentACIPath. If the label already exists its value will be updated to
 // the new value.
-func AddLabel(acipath, name, value string) error {
+func (a *ACBuild) AddLabel(name, value string) (err error) {
+	if err = a.lock(); err != nil {
+		return err
+	}
+	defer func() {
+		if err1 := a.unlock(); err == nil {
+			err = err1
+		}
+	}()
+
 	acid, err := types.NewACIdentifier(name)
 	if err != nil {
 		return err
@@ -50,16 +59,25 @@ func AddLabel(acipath, name, value string) error {
 				Value: value,
 			})
 	}
-	return util.ModifyManifest(fn, acipath)
+	return util.ModifyManifest(fn, a.CurrentACIPath)
 }
 
 // RemoveLabel will remove the label with the given name from the untarred ACI
-// stored at acipath
-func RemoveLabel(acipath, name string) error {
+// stored at a.CurrentACIPath
+func (a *ACBuild) RemoveLabel(name string) (err error) {
+	if err = a.lock(); err != nil {
+		return err
+	}
+	defer func() {
+		if err1 := a.unlock(); err == nil {
+			err = err1
+		}
+	}()
+
 	acid, err := types.NewACIdentifier(name)
 	if err != nil {
 		return err
 	}
 
-	return util.ModifyManifest(removeLabelFromMan(*acid), acipath)
+	return util.ModifyManifest(removeLabelFromMan(*acid), a.CurrentACIPath)
 }

--- a/lib/set-exec.go
+++ b/lib/set-exec.go
@@ -21,13 +21,23 @@ import (
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 )
 
-// SetExec sets the exec command for the untarred ACI stored at acipath.
-func SetExec(acipath string, cmd []string) error {
+// SetExec sets the exec command for the untarred ACI stored at
+// a.CurrentACIPath.
+func (a *ACBuild) SetExec(cmd []string) (err error) {
+	if err = a.lock(); err != nil {
+		return err
+	}
+	defer func() {
+		if err1 := a.unlock(); err == nil {
+			err = err1
+		}
+	}()
+
 	fn := func(s *schema.ImageManifest) {
 		if s.App == nil {
 			s.App = &types.App{}
 		}
 		s.App.Exec = cmd
 	}
-	return util.ModifyManifest(fn, acipath)
+	return util.ModifyManifest(fn, a.CurrentACIPath)
 }

--- a/lib/set-group.go
+++ b/lib/set-group.go
@@ -24,8 +24,17 @@ import (
 )
 
 // SetGroup sets the group the pod will run as in the untarred ACI stored at
-// acipath.
-func SetGroup(acipath, group string) error {
+// a.CurrentACIPath.
+func (a *ACBuild) SetGroup(group string) (err error) {
+	if err = a.lock(); err != nil {
+		return err
+	}
+	defer func() {
+		if err1 := a.unlock(); err == nil {
+			err = err1
+		}
+	}()
+
 	if group == "" {
 		return fmt.Errorf("group cannot be empty")
 	}
@@ -35,5 +44,5 @@ func SetGroup(acipath, group string) error {
 		}
 		s.App.Group = group
 	}
-	return util.ModifyManifest(fn, acipath)
+	return util.ModifyManifest(fn, a.CurrentACIPath)
 }

--- a/lib/set-name.go
+++ b/lib/set-name.go
@@ -23,8 +23,17 @@ import (
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 )
 
-// SetName sets the name for the untarred ACI stored at acipath
-func SetName(acipath, name string) error {
+// SetName sets the name for the untarred ACI stored at a.CurrentACIPath
+func (a *ACBuild) SetName(name string) (err error) {
+	if err = a.lock(); err != nil {
+		return err
+	}
+	defer func() {
+		if err1 := a.unlock(); err == nil {
+			err = err1
+		}
+	}()
+
 	if name == "" {
 		return fmt.Errorf("name cannot be empty")
 	}
@@ -36,5 +45,5 @@ func SetName(acipath, name string) error {
 	fn := func(s *schema.ImageManifest) {
 		s.Name = *acid
 	}
-	return util.ModifyManifest(fn, acipath)
+	return util.ModifyManifest(fn, a.CurrentACIPath)
 }

--- a/lib/set-user.go
+++ b/lib/set-user.go
@@ -24,8 +24,17 @@ import (
 )
 
 // SetUser sets the user the pod will run as in the untarred ACI stored at
-// acipath.
-func SetUser(acipath, user string) error {
+// a.CurrentACIPath.
+func (a *ACBuild) SetUser(user string) (err error) {
+	if err = a.lock(); err != nil {
+		return err
+	}
+	defer func() {
+		if err1 := a.unlock(); err == nil {
+			err = err1
+		}
+	}()
+
 	if user == "" {
 		return fmt.Errorf("user cannot be empty")
 	}
@@ -35,5 +44,5 @@ func SetUser(acipath, user string) error {
 		}
 		s.App.User = user
 	}
-	return util.ModifyManifest(fn, acipath)
+	return util.ModifyManifest(fn, a.CurrentACIPath)
 }

--- a/registry/fetch.go
+++ b/registry/fetch.go
@@ -43,11 +43,11 @@ var (
 )
 
 func (r Registry) tmppath() string {
-	return path.Join(r.Depstore, "tmp.aci")
+	return path.Join(r.DepStoreTarPath, "tmp.aci")
 }
 
 func (r Registry) tmpuncompressedpath() string {
-	return path.Join(r.Depstore, "tmp.uncompressed.aci")
+	return path.Join(r.DepStoreTarPath, "tmp.uncompressed.aci")
 }
 
 // FetchAndRender will fetch the given image and all of its dependencies if
@@ -69,7 +69,8 @@ func (r Registry) FetchAndRender(imagename types.ACIdentifier, labels types.Labe
 	}
 
 	for _, fs := range filesToRender {
-		ex, err := util.Exists(path.Join(r.Scratchpath, fs.Key, "rendered"))
+		ex, err := util.Exists(
+			path.Join(r.DepStoreExpandedPath, fs.Key, "rendered"))
 		if err != nil {
 			return err
 		}
@@ -78,13 +79,14 @@ func (r Registry) FetchAndRender(imagename types.ACIdentifier, labels types.Labe
 			continue
 		}
 
-		err = util.UnTar(path.Join(r.Depstore, fs.Key),
-			path.Join(r.Scratchpath, fs.Key), fs.FileMap)
+		err = util.UnTar(path.Join(r.DepStoreTarPath, fs.Key),
+			path.Join(r.DepStoreExpandedPath, fs.Key), fs.FileMap)
 		if err != nil {
 			return err
 		}
 
-		rfile, err := os.Create(path.Join(r.Scratchpath, fs.Key, "rendered"))
+		rfile, err := os.Create(
+			path.Join(r.DepStoreExpandedPath, fs.Key, "rendered"))
 		if err != nil {
 			return err
 		}
@@ -133,18 +135,19 @@ func (r Registry) fetchACIWithSize(imagename types.ACIdentifier, labels types.La
 		return err
 	}
 
-	err = os.Rename(r.tmpuncompressedpath(), path.Join(r.Depstore, id))
+	err = os.Rename(r.tmpuncompressedpath(), path.Join(r.DepStoreTarPath, id))
 	if err != nil {
 		return err
 	}
 
-	err = os.MkdirAll(path.Join(r.Scratchpath, id, aci.RootfsDir), 0755)
+	err = os.MkdirAll(
+		path.Join(r.DepStoreExpandedPath, id, aci.RootfsDir), 0755)
 	if err != nil {
 		return err
 	}
 
-	err = getManifestFromTar(path.Join(r.Depstore, id),
-		path.Join(r.Scratchpath, id, aci.ManifestFile))
+	err = getManifestFromTar(path.Join(r.DepStoreTarPath, id),
+		path.Join(r.DepStoreExpandedPath, id, aci.ManifestFile))
 	if err != nil {
 		return err
 	}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -47,16 +47,16 @@ var (
 )
 
 type Registry struct {
-	Depstore    string
-	Scratchpath string
-	Insecure    bool
-	Debug       bool
+	DepStoreTarPath      string
+	DepStoreExpandedPath string
+	Insecure             bool
+	Debug                bool
 }
 
 // Read the ACI contents stream given the key. Use ResolveKey to
 // convert an image ID to the relative provider's key.
 func (r Registry) ReadStream(key string) (io.ReadCloser, error) {
-	return os.Open(path.Join(r.Depstore, key))
+	return os.Open(path.Join(r.DepStoreTarPath, key))
 }
 
 // Converts an image ID to the, if existent, key under which the
@@ -72,7 +72,7 @@ func (r Registry) ResolveKey(key string) (string, error) {
 		key = key[:lenKey]
 	}
 
-	files, err := ioutil.ReadDir(r.Depstore)
+	files, err := ioutil.ReadDir(r.DepStoreTarPath)
 	if err != nil {
 		return "", err
 	}
@@ -97,18 +97,18 @@ func (r Registry) HashToKey(h hash.Hash) string {
 
 // Returns the manifest for the ACI with the given key
 func (r Registry) GetImageManifest(key string) (*schema.ImageManifest, error) {
-	return util.GetManifest(path.Join(r.Scratchpath, key))
+	return util.GetManifest(path.Join(r.DepStoreExpandedPath, key))
 }
 
 // Returns the key for the ACI with the given name and labels
 func (r Registry) GetACI(name types.ACIdentifier, labels types.Labels) (string, error) {
-	files, err := ioutil.ReadDir(r.Scratchpath)
+	files, err := ioutil.ReadDir(r.DepStoreExpandedPath)
 	if err != nil {
 		return "", err
 	}
 nextkey:
 	for _, file := range files {
-		man, err := util.GetManifest(path.Join(r.Scratchpath, file.Name()))
+		man, err := util.GetManifest(path.Join(r.DepStoreExpandedPath, file.Name()))
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
The library was refactored so that all the exposed functions were
attached to a struct containing the information about the current
context. This makes using the library much cleaner.

The Registry struct had some of its fields renamed to be consistent with
the new struct in the library.