### PR TITLE
version: added command

### DIFF
--- a/acbuild/acbuild.go
+++ b/acbuild/acbuild.go
@@ -124,7 +124,7 @@ func runWrapper(cf func(cmd *cobra.Command, args []string) (exit int)) func(cmd 
 			return
 		}
 
-		contextualCommands := []string{"begin", "write", "end"}
+		contextualCommands := []string{"begin", "write", "end", "version"}
 		command := strings.Split(cmd.Use, " ")[0]
 		for _, cc := range contextualCommands {
 			if command == cc {

--- a/acbuild/version.go
+++ b/acbuild/version.go
@@ -1,0 +1,46 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/spf13/cobra"
+
+	"github.com/appc/acbuild/lib"
+)
+
+var (
+	cmdVersion = &cobra.Command{
+		Use:     "version",
+		Short:   "Get the version of acbuild",
+		Example: "acbuild version",
+		Run:     runWrapper(runVersion),
+	}
+)
+
+func init() {
+	cmdAcbuild.AddCommand(cmdVersion)
+}
+
+func runVersion(cmd *cobra.Command, args []string) (exit int) {
+	if len(args) != 0 {
+		cmd.Usage()
+		return 1
+	}
+
+	stdout("acbuild version %s", lib.Version)
+	stdout("appc version %s", lib.AppcVersion)
+
+	return 0
+}

--- a/build
+++ b/build
@@ -3,6 +3,8 @@ set -e
 
 ORG_PATH="github.com/appc"
 REPO_PATH="${ORG_PATH}/acbuild"
+VERSION=$(git describe --dirty)
+GLDFLAGS="-X github.com/appc/acbuild/lib.Version=\"${VERSION}\""
 
 if [ ! -h gopath/src/${REPO_PATH} ]; then
 	mkdir -p gopath/src/${ORG_PATH}
@@ -23,4 +25,4 @@ if [ "${GOOS}" = "freebsd" ]; then
 fi
 
 echo "Building acbuild..."
-go build -o $GOBIN/acbuild ${REPO_PATH}/acbuild
+go build -o $GOBIN/acbuild -ldflags "${GLDFLAGS}" ${REPO_PATH}/acbuild

--- a/lib/version.go
+++ b/lib/version.go
@@ -1,0 +1,20 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lib
+
+import "github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/schema"
+
+var Version = "0.0.0+was-not-built-correctly"
+var AppcVersion = schema.AppContainerVersion


### PR DESCRIPTION
The version command was added. The version string gets set at compile
time by linker flags. If the build script is not used, the version will
read: "0.0.0+was-not-built-correctly".

Note that the build now fails when there are no git tags.