### PR TITLE
write: Update to perform overwriting with truncate rather than remove

### DIFF
--- a/lib/write.go
+++ b/lib/write.go
@@ -51,6 +51,8 @@ func (a *ACBuild) Write(output string, overwrite, sign bool, gpgflags []string) 
 		return fmt.Errorf("can't write ACI, name was never set")
 	}
 
+	fileFlags := os.O_CREATE | os.O_WRONLY
+
 	ex, err := util.Exists(output)
 	if err != nil {
 		return err
@@ -59,13 +61,10 @@ func (a *ACBuild) Write(output string, overwrite, sign bool, gpgflags []string) 
 		if !overwrite {
 			return fmt.Errorf("ACI already exists: %s", output)
 		}
-		err := os.Remove(output)
-		if err != nil {
-			return err
-		}
+		fileFlags |= os.O_TRUNC
 	}
 
-	ofile, err := os.OpenFile(output, os.O_CREATE|os.O_WRONLY, 0644)
+	ofile, err := os.OpenFile(output, fileFlags, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This changes the overwrite handling to adding the O_TRUNC flag onto the
OpenFile, rather than performing a remove and then recreate.

One primary use for this is running acbuild from a container, where the
ACI file is a bind mount in directly to the file. In this case, the
remove call won't work, but truncating the file is possible.

@jonboulle @dgonyeo 