### PR TITLE
write: Instrumented gzip compression on the resulting image

### DIFF
--- a/acbuild/write.go
+++ b/acbuild/write.go
@@ -33,7 +33,7 @@ var (
 func init() {
 	cmdAcbuild.AddCommand(cmdWrite)
 
-	cmdWrite.Flags().BoolVar(&overwrite, "overwrite", false, "overwrite output ACI")
+	cmdWrite.Flags().BoolVar(&overwrite, "overwrite", false, "overwrite the resulting ACI")
 	cmdWrite.Flags().BoolVar(&sign, "sign", false, "sign the resulting ACI")
 }
 


### PR DESCRIPTION
This changes the write operation to compress the resulting image with gzip.
    
Currently, it only does gzip. The ACI spec references gzip, bzip2, and xz.
Go has a built in gzip writer, but only a bzip2 reader. XZ is possible, however
it requires linking to libxz and then requiring it at runtime.
    
This changes also reorders some of the file closing within the write function.
It moves the closes from being done in line to being defered. The gzip.Writer
exposes a Close function, and want to ensure the Close options are done in
the proper order, and done across all three.
    
The ACI may be removed on a failure, however it is fine to remove the file
before closing, it will clean up properly.