### PR TITLE
tests: Added test for begin when starting with local ACI

### DIFF
--- a/tests/begin_test.go
+++ b/tests/begin_test.go
@@ -15,8 +15,11 @@
 package tests
 
 import (
+	"archive/tar"
 	"io/ioutil"
+	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/aci"
@@ -25,16 +28,125 @@ import (
 	"github.com/kylelemons/godebug/pretty"
 )
 
-func TestBegin(t *testing.T) {
-	// Call begin
-	tmpdir, err := setUpTest()
+func TestBeginEmpty(t *testing.T) {
+	tmpdir := mustTempDir()
+	defer cleanUpTest(tmpdir)
+
+	err := runAcbuild(tmpdir, "begin")
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
+
+	wim := schema.ImageManifest{
+		ACKind:    schema.ImageManifestKind,
+		ACVersion: schema.AppContainerVersion,
+		Name:      *types.MustACIdentifier("acbuild-unnamed"),
+		App: &types.App{
+			Exec:  nil,
+			User:  "0",
+			Group: "0",
+		},
+	}
+
+	checkMinimalContainer(t, path.Join(tmpdir, ".acbuild", "currentaci"), wim)
+}
+
+func TestBeginLocalACI(t *testing.T) {
+	wim := schema.ImageManifest{
+		ACKind:    schema.ImageManifestKind,
+		ACVersion: schema.AppContainerVersion,
+		Name:      *types.MustACIdentifier("acbuild-begin-test"),
+		Labels: types.Labels{
+			types.Label{
+				Name:  *types.MustACIdentifier("version"),
+				Value: "9001",
+			},
+		},
+		App: &types.App{
+			Exec:  types.Exec{"/bin/nethack4", "-D", "wizard"},
+			User:  "0",
+			Group: "0",
+			Environment: types.Environment{
+				types.EnvironmentVariable{
+					Name:  "FOO",
+					Value: "BAR",
+				},
+			},
+			MountPoints: []types.MountPoint{
+				types.MountPoint{
+					Name:     *types.MustACName("nethack4-data"),
+					Path:     "/root/nethack4-data",
+					ReadOnly: true,
+				},
+			},
+			Ports: []types.Port{
+				types.Port{
+					Name:     *types.MustACName("gopher"),
+					Protocol: "tcp",
+					Port:     70,
+					Count:    1,
+				},
+			},
+		},
+		Annotations: types.Annotations{
+			types.Annotation{
+				Name:  *types.MustACIdentifier("author"),
+				Value: "the acbuild devs",
+			},
+		},
+		Dependencies: types.Dependencies{
+			types.Dependency{
+				ImageName: *types.MustACIdentifier("quay.io/gnu/hurd"),
+			},
+		},
+	}
+
+	manblob, err := wim.MarshalJSON()
+	if err != nil {
+		panic(err)
+	}
+
+	tmpexpandedaci := mustTempDir()
+	defer os.RemoveAll(tmpexpandedaci)
+
+	err = ioutil.WriteFile(path.Join(tmpexpandedaci, aci.ManifestFile), manblob, 0644)
+	if err != nil {
+		panic(err)
+	}
+
+	err = os.Mkdir(path.Join(tmpexpandedaci, aci.RootfsDir), 0755)
+	if err != nil {
+		panic(err)
+	}
+
+	tmpaci, err := ioutil.TempFile("", "acbuild-test")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmpaci.Name())
+
+	aw := aci.NewImageWriter(wim, tar.NewWriter(tmpaci))
+	err = filepath.Walk(tmpexpandedaci, aci.BuildWalker(tmpexpandedaci, aw, nil))
+	aw.Close()
+	if err != nil {
+		panic(err)
+	}
+	tmpaci.Close()
+
+	tmpdir := mustTempDir()
 	defer cleanUpTest(tmpdir)
 
+	err = runAcbuild(tmpdir, "begin", tmpaci.Name())
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	checkMinimalContainer(t, path.Join(tmpdir, ".acbuild", "currentaci"), wim)
+}
+
+func checkMinimalContainer(t *testing.T, acipath string, expectedManifest schema.ImageManifest) {
 	// Check that there are no files in the rootfs
-	files, err := ioutil.ReadDir(path.Join(tmpdir, ".acbuild", "currentaci", aci.RootfsDir))
+	files, err := ioutil.ReadDir(path.Join(acipath, aci.RootfsDir))
 	if err != nil {
 		t.Errorf("%v", err)
 	}
@@ -43,7 +155,7 @@ func TestBegin(t *testing.T) {
 	}
 
 	// Check that the manifest is no bigger than it needs to be
-	manblob, err := ioutil.ReadFile(path.Join(tmpdir, ".acbuild", "currentaci", aci.ManifestFile))
+	manblob, err := ioutil.ReadFile(path.Join(acipath, aci.ManifestFile))
 	if err != nil {
 		t.Errorf("%v", err)
 	}
@@ -55,18 +167,7 @@ func TestBegin(t *testing.T) {
 		t.Errorf("invalid manifest schema: %v", err)
 	}
 
-	expectedMan := schema.ImageManifest{
-		ACKind:    schema.ImageManifestKind,
-		ACVersion: schema.AppContainerVersion,
-		Name:      *types.MustACIdentifier("acbuild-unnamed"),
-		App: &types.App{
-			Exec:  nil,
-			User:  "0",
-			Group: "0",
-		},
-	}
-
-	if str := pretty.Compare(man, expectedMan); str != "" {
+	if str := pretty.Compare(man, expectedManifest); str != "" {
 		t.Errorf("unexpected manifest:\n%s", str)
 	}
 }

--- a/tests/common.go
+++ b/tests/common.go
@@ -44,20 +44,25 @@ func runAcbuild(workingDir string, args ...string) error {
 	return cmd.Run()
 }
 
-func setUpTest() (string, error) {
-	tmpdir, err := ioutil.TempDir("", "acbuild-test")
+func setUpTest() string {
+	tmpdir := mustTempDir()
+
+	err := runAcbuild(tmpdir, "begin")
 	if err != nil {
-		return "", err
+		panic(err)
 	}
 
-	err = runAcbuild(tmpdir, "begin")
-	if err != nil {
-		return "", err
-	}
-
-	return tmpdir, nil
+	return tmpdir
 }
 
 func cleanUpTest(tmpdir string) error {
 	return os.RemoveAll(tmpdir)
+}
+
+func mustTempDir() string {
+	dir, err := ioutil.TempDir("", "acbuild-test")
+	if err != nil {
+		panic(err)
+	}
+	return dir
 }


### PR DESCRIPTION
Writes out an ACI, calls begin on it, and inspects it to make sure no
files were added to the rootfs and the manifest wasn't modified.