### PR TITLE
build: removed quotes from acbuild version string in build script

### DIFF
--- a/build
+++ b/build
@@ -4,7 +4,7 @@ set -e
 ORG_PATH="github.com/appc"
 REPO_PATH="${ORG_PATH}/acbuild"
 VERSION=$(git describe --dirty)
-GLDFLAGS="-X github.com/appc/acbuild/lib.Version=\"${VERSION}\""
+GLDFLAGS="-X github.com/appc/acbuild/lib.Version=${VERSION}"
 
 if [ ! -h gopath/src/${REPO_PATH} ]; then
 	mkdir -p gopath/src/${ORG_PATH}


### PR DESCRIPTION
Was:
./bin/acbuild version
acbuild version "v0.1.0"
appc version 0.7.1+git

Is now:
./bin/acbuild version
acbuild version v0.1.0-dirty
appc version 0.7.1+git