### PR TITLE
run: --debug flag caused a panic with the Uncompress progress bar

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -41,7 +41,7 @@
 		},
 		{
 			"ImportPath": "github.com/coreos/ioprogress",
-			"Rev": "e7fc03058804de5488baed8df5b89f3924b9ec9a"
+			"Rev": "4637e494fd9b23c5565ee193e89f91fdc1639bc0"
 		},
 		{
 			"ImportPath": "github.com/coreos/rkt/pkg/fileutil",

--- a/Godeps/_workspace/src/github.com/coreos/ioprogress/draw.go
+++ b/Godeps/_workspace/src/github.com/coreos/ioprogress/draw.go
@@ -108,6 +108,9 @@ func DrawTextFormatBarForW(width int64, w io.Writer) DrawTextFormatFunc {
 
 	return func(progress, total int64) string {
 		current := int64((float64(progress) / float64(total)) * float64(width))
+		if current < 0 || current > width {
+			return fmt.Sprintf("[%s]", strings.Repeat(" ", int(width)))
+		}
 		return fmt.Sprintf(
 			"[%s%s]",
 			strings.Repeat("=", int(current)),

--- a/Godeps/_workspace/src/github.com/coreos/ioprogress/draw_test.go
+++ b/Godeps/_workspace/src/github.com/coreos/ioprogress/draw_test.go
@@ -44,6 +44,24 @@ func TestDrawTextFormatBar(t *testing.T) {
 	if actual != expected {
 		t.Fatalf("bad: %s", actual)
 	}
+
+	actual = f(0, 0)
+	expected = "[        ]"
+	if actual != expected {
+		t.Fatalf("bad: %s", actual)
+	}
+
+	actual = f(-10, 10)
+	expected = "[        ]"
+	if actual != expected {
+		t.Fatalf("bad: %s", actual)
+	}
+
+	actual = f(20, 10)
+	expected = "[        ]"
+	if actual != expected {
+		t.Fatalf("bad: %s", actual)
+	}
 }
 
 func TestDrawTextFormatBytes(t *testing.T) {
@@ -69,4 +87,4 @@ func TestDrawTextFormatBytes(t *testing.T) {
 	}
 }
 
-const drawTerminalStr = "0/100\r20/100\r\n"
+const drawTerminalStr = "0/100\n20/100\n\n"

--- a/Godeps/_workspace/src/github.com/coreos/ioprogress/reader_test.go
+++ b/Godeps/_workspace/src/github.com/coreos/ioprogress/reader_test.go
@@ -31,7 +31,7 @@ func TestReader(t *testing.T) {
 	}
 }
 
-const drawReaderStr = "0/6\r2/6\r4/6\r6/6\r6/6\r\n"
+const drawReaderStr = "0/6\n2/6\n4/6\n6/6\n6/6\n\n"
 
 // testReader is a test structure to help with testing the Reader by
 // returning fixed slices of data.

--- a/registry/fetch.go
+++ b/registry/fetch.go
@@ -238,14 +238,6 @@ func (r Registry) uncompress() error {
 		return fmt.Errorf("downloaded ACI is of an unknown type")
 	}
 
-	if r.Debug {
-		finfo, err := acifile.Stat()
-		if err != nil {
-			return err
-		}
-		in = newIoprogress("Uncompressing", finfo.Size(), in)
-	}
-
 	out, err := os.OpenFile(r.tmpuncompressedpath(),
 		os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {


### PR DESCRIPTION
The recent refactor resulted in the registry being correctly passed the
debug value, which exposed an issue with an additional progress bar that
was being drawn when uncompressing a dependency.

The panic was a combination of the logic drawing the bar passing the
ioprogress library a number that was too small for the total size, and
the ioprogress library not having a patch to be able to handle incorrect
numbers.

This commit removes the uncompressing bar, and updates the ioprogress
library.

Fixes https://github.com/appc/acbuild/issues/56