### PR TITLE
begin: fixed a silly typo that broke fetching remote ACIs

### DIFF
--- a/lib/begin.go
+++ b/lib/begin.go
@@ -171,7 +171,7 @@ func (a *ACBuild) beginFromImage(start string, insecure bool) error {
 		return err
 	}
 
-	if len(files) != 0 {
+	if len(files) != 1 {
 		var filelist string
 		for _, file := range files {
 			if filelist == "" {


### PR DESCRIPTION
Sorry about this, but it looks like I typo'd a number when making a change for code review at some point. Don't know how I didn't catch this sooner.