### PR TITLE
examples: Added example build scripts for acserver and nginx

### DIFF
--- a/examples/build-acserver.sh
+++ b/examples/build-acserver.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Building acserver..."
+CGO_ENABLED=0 GOOS=linux go build -o acserver -a -tags netgo -ldflags '-w' github.com/appc/acserver
+
+acbuild --debug begin
+
+trap "{ export EXT=$?; acbuild --debug end && exit $EXT; }" EXIT
+
+acbuild --debug set-name example.com/acserver
+acbuild --debug copy acserver /bin/acserver
+acbuild --debug copy $GOPATH/src/github.com/appc/acserver/templates /templates
+acbuild --debug set-exec /bin/acserver 
+acbuild --debug port add http tcp 3001
+acbuild --debug mount add acis /acis
+acbuild --debug label add arch amd64
+acbuild --debug label add os linux
+acbuild --debug write --overwrite acserver-latest-linux-amd64.aci
+
+rm acserver

--- a/examples/build-nginx.sh
+++ b/examples/build-nginx.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+acbuild --debug begin quay.io/listhub/alpine
+
+trap "{ export EXT=$?; acbuild --debug end && exit $EXT; }" EXIT
+
+acbuild --debug set-name example.com/nginx
+acbuild --debug run apk update
+acbuild --debug run apk add nginx
+acbuild --debug set-exec -- /usr/sbin/nginx -g "daemon off;"
+acbuild --debug port add http tcp 80
+acbuild --debug mount add html /usr/share/nginx/html
+acbuild --debug label add arch amd64
+acbuild --debug label add os linux
+acbuild --debug write --overwrite nginx-latest-linux-amd64.aci


### PR DESCRIPTION
The nginx example requires https://github.com/appc/acbuild/pull/58 to function correctly.