### PR TITLE
examples: added check if build-nginx.sh is running as root

### DIFF
--- a/examples/build-nginx.sh
+++ b/examples/build-nginx.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
+if [ "$EUID" -ne 0 ]; then
+    echo "This script uses functionality which requires root privileges"
+    exit 1
+fi
+
 acbuild --debug begin quay.io/listhub/alpine
 
 trap "{ export EXT=$?; acbuild --debug end && exit $EXT; }" EXIT


### PR DESCRIPTION
build-nginx.sh must be run as root. This adds a check for that.