### PR TITLE
vagrant: added initial vagrant scripts

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,18 @@
+Vagrant.configure('2') do |config|
+    # grab Ubuntu 15.04 official image
+    config.vm.box = "ubuntu/vivid64" # Ubuntu 15.04
+
+    # fix issues with slow dns http://serverfault.com/a/595010
+    config.vm.provider :virtualbox do |vb, override|
+        vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+        vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+        # add more ram, the default isn't enough for the build
+        vb.customize ["modifyvm", :id, "--memory", "768"]
+    end
+
+    # install Build Dependencies (GOLANG)
+    config.vm.provision :shell, :privileged => false, :path => "scripts/vagrant-install-go.sh"
+
+    # Install acbuild
+    config.vm.provision :shell, :privileged => false, :path => "scripts/vagrant-install-acbuild.sh"
+end

--- a/scripts/vagrant-install-acbuild.sh
+++ b/scripts/vagrant-install-acbuild.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -xe
+export DEBIAN_FRONTEND=noninteractive
+
+pushd /vagrant
+./build
+sudo cp -v bin/* /usr/local/bin
+
+curl -s -q -L -o rkt.tar.gz https://github.com/coreos/rkt/releases/download/v0.9.0/rkt-v0.9.0.tar.gz -z rkt.tar.gz
+tar xfv rkt.tar.gz
+sudo cp -v rkt-v0.9.0/* /usr/local/bin

--- a/scripts/vagrant-install-go.sh
+++ b/scripts/vagrant-install-go.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -x
+
+export DEBIAN_FRONTEND=noninteractive
+VERSION=1.4.2
+OS=linux
+ARCH=amd64
+
+prefix=/usr/local
+
+# grab go
+if ! [ -e $prefix/go ]; then
+
+    wget -q https://storage.googleapis.com/golang/go$VERSION.$OS-$ARCH.tar.gz
+    sudo tar -C $prefix -xzf go$VERSION.$OS-$ARCH.tar.gz
+fi
+
+# setup user environment variables
+echo "export GOROOT=$prefix/go" |sudo tee /etc/profile.d/01go.sh
+cat << 'EOF' |sudo tee -a /etc/profile.d/go.sh
+
+export GOPATH=$HOME/.gopath
+
+[ -e $GOPATH ] || mkdir -p $GOPATH
+
+export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+EOF
+
+# not essential but go get depends on it
+which git || sudo apt-get install -y git


### PR DESCRIPTION
Added a Vagrantfile and relevant scripts (largely stolen from rkt).
`vagrant up` should produce a machine with both acbuild and rkt 0.9.0
(will be updated once rkt is released) in the path.