### PR TITLE
*: rename UnTar -> ExtractImage

### DIFF
--- a/lib/begin.go
+++ b/lib/begin.go
@@ -120,7 +120,7 @@ func (a *ACBuild) beginFromImage(start string, insecure bool) error {
 		if finfo.IsDir() {
 			return fmt.Errorf("provided starting ACI is a directory: %s", start)
 		}
-		return util.UnTar(start, a.CurrentACIPath, nil)
+		return util.ExtractImage(start, a.CurrentACIPath, nil)
 	} else if !os.IsNotExist(err) {
 		return err
 	}
@@ -183,5 +183,5 @@ func (a *ACBuild) beginFromImage(start string, insecure bool) error {
 		panic("unexpected number of files in store after download: " + filelist)
 	}
 
-	return util.UnTar(path.Join(tmpDepStoreTarPath, files[0].Name()), a.CurrentACIPath, nil)
+	return util.ExtractImage(path.Join(tmpDepStoreTarPath, files[0].Name()), a.CurrentACIPath, nil)
 }

--- a/registry/fetch.go
+++ b/registry/fetch.go
@@ -90,7 +90,7 @@ func (r Registry) FetchAndRender(imagename types.ACIdentifier, labels types.Labe
 			continue
 		}
 
-		err = util.UnTar(path.Join(r.DepStoreTarPath, fs.Key),
+		err = util.ExtractImage(path.Join(r.DepStoreTarPath, fs.Key),
 			path.Join(r.DepStoreExpandedPath, fs.Key), fs.FileMap)
 		if err != nil {
 			return err

--- a/util/files.go
+++ b/util/files.go
@@ -53,20 +53,20 @@ func Exists(path string) (bool, error) {
 	return false, err
 }
 
-// UnTar will extract the contents at the tar file at tarpath to the directory
+// ExtractImage will extract the contents of the image at path to the directory
 // at dst. If fileMap is set, only files in it will be extracted.
-func UnTar(tarpath, dst string, fileMap map[string]struct{}) error {
+func ExtractImage(path, dst string, fileMap map[string]struct{}) error {
 	dst, err := filepath.Abs(dst)
 	if err != nil {
 		return err
 	}
-	tarfile, err := os.Open(tarpath)
+	file, err := os.Open(path)
 	if err != nil {
 		return err
 	}
-	defer tarfile.Close()
+	defer file.Close()
 
-	dr, err := aci.NewCompressedReader(tarfile)
+	dr, err := aci.NewCompressedReader(file)
 	if err != nil {
 		return fmt.Errorf("error decompressing image: %v", err)
 	}


### PR DESCRIPTION
Noticed in #68. The latter is more accurate, particularly since this now
deals with compressed images. Also cleans up a few other variable names.