### PR TITLE
cat-manifest: added implementation

### DIFF
--- a/acbuild/acbuild.go
+++ b/acbuild/acbuild.go
@@ -126,14 +126,15 @@ func runWrapper(cf func(cmd *cobra.Command, args []string) (exit int)) func(cmd 
 			return
 		}
 
-		contextualCommands := []string{"begin", "write", "end", "version"}
 		command := strings.Split(cmd.Use, " ")[0]
-		for _, cc := range contextualCommands {
-			if command == cc {
-				stderr("Can't use the --modify flag with %s.", command)
-				cmdExitCode = 1
-				return
-			}
+		switch command {
+		case "cat-manifest":
+			cmdExitCode = runCatOnACI(aciToModify)
+			return
+		case "begin", "write", "end", "version":
+			stderr("Can't use the --modify flag with %s.", command)
+			cmdExitCode = 1
+			return
 		}
 
 		finfo, err := os.Stat(aciToModify)

--- a/acbuild/cat-manifest.go
+++ b/acbuild/cat-manifest.go
@@ -1,0 +1,65 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/spf13/cobra"
+
+	"github.com/appc/acbuild/lib"
+)
+
+var (
+	prettyPrint bool
+
+	cmdCat = &cobra.Command{
+		Use:     "cat-manifest",
+		Short:   "Print the manifest from the current build",
+		Example: "acbuild cat-manifest",
+		Run:     runWrapper(runCat),
+	}
+)
+
+func init() {
+	cmdAcbuild.AddCommand(cmdCat)
+	cmdCat.Flags().BoolVar(&prettyPrint, "pretty-print", false, "Print the manifest with whitespace")
+}
+
+func runCat(cmd *cobra.Command, args []string) (exit int) {
+	if len(args) != 0 {
+		cmd.Usage()
+		return 1
+	}
+
+	if debug {
+		stderr("Printing manifest from current build")
+	}
+
+	err := newACBuild().CatManifest(prettyPrint)
+	if err != nil {
+		stderr("cat-manifest: %v", err)
+		return 1
+	}
+
+	return 0
+}
+
+func runCatOnACI(aciToModify string) int {
+	err := lib.CatManifest(aciToModify, prettyPrint)
+	if err != nil {
+		stderr("cat-manifest: %v", err)
+		return 1
+	}
+	return 0
+}

--- a/lib/cat-manifest.go
+++ b/lib/cat-manifest.go
@@ -1,0 +1,97 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lib
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/aci"
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/schema"
+
+	"github.com/appc/acbuild/util"
+)
+
+// CatManifest will print to stdout the manifest from the expanded ACI stored
+// at a.CurrentACIPath, optionally inserting whitespace to make it more human
+// readable.
+func (a *ACBuild) CatManifest(prettyPrint bool) (err error) {
+	if err = a.lock(); err != nil {
+		return err
+	}
+	defer func() {
+		if err1 := a.unlock(); err == nil {
+			err = err1
+		}
+	}()
+
+	man, err := util.GetManifest(a.CurrentACIPath)
+	if err != nil {
+		return err
+	}
+
+	return util.PrintManifest(man, prettyPrint)
+}
+
+// CatManifest will print to stdout the manifest from the ACI stored at
+// aciPath, optionally inserting whitespace to make it more human readable.
+func CatManifest(aciPath string, prettyPrint bool) (err error) {
+	finfo, err := os.Stat(aciPath)
+	switch {
+	case os.IsNotExist(err):
+		return fmt.Errorf("no such file or directory: %s", aciPath)
+	case err != nil:
+		return err
+	case finfo.IsDir():
+		return fmt.Errorf("%s is a directory, not an ACI", aciPath)
+	default:
+		break
+	}
+
+	file, err := os.Open(aciPath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	tr, err := aci.NewCompressedTarReader(file)
+	if err != nil {
+		return fmt.Errorf("error decompressing image: %v", err)
+	}
+	defer tr.Close()
+
+	for {
+		hdr, err := tr.Next()
+		switch {
+		case err == io.EOF:
+			return fmt.Errorf("manifest not found in ACI %s", aciPath)
+		case err != nil:
+			return err
+		case hdr.Name == "manifest":
+			manblob, err := ioutil.ReadAll(tr)
+			if err != nil {
+				return err
+			}
+			var man schema.ImageManifest
+			err = man.UnmarshalJSON(manblob)
+			if err != nil {
+				return err
+			}
+			return util.PrintManifest(&man, prettyPrint)
+		}
+	}
+}

--- a/util/manifest.go
+++ b/util/manifest.go
@@ -15,6 +15,8 @@
 package util
 
 import (
+	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -73,5 +75,22 @@ func ModifyManifest(fn func(*schema.ImageManifest), acipath string) error {
 		return err
 	}
 
+	return nil
+}
+
+// PrintManifest will print the given manifest to stdout, optionally inserting
+// whitespace to make it more human readable.
+func PrintManifest(man *schema.ImageManifest, prettyPrint bool) error {
+	var manblob []byte
+	var err error
+	if prettyPrint {
+		manblob, err = json.MarshalIndent(man, "", "    ")
+	} else {
+		manblob, err = man.MarshalJSON()
+	}
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(manblob))
 	return nil
 }


### PR DESCRIPTION
This commit adds a command to cat the manifest, either from the current
build or from a given aci.