### PR TITLE
replace-manifest: added command to replace manifest with a new one

### DIFF
--- a/acbuild/replace-manifest.go
+++ b/acbuild/replace-manifest.go
@@ -1,0 +1,56 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/spf13/cobra"
+)
+
+var (
+	cmdReplaceMan = &cobra.Command{
+		Use:     "replace-manifest PATH_TO_MANIFEST",
+		Short:   "Replace the manifest in the current build",
+		Example: "acbuild replace-manifest path/to/manifest",
+		Run:     runWrapper(runReplaceMan),
+	}
+)
+
+func init() {
+	cmdAcbuild.AddCommand(cmdReplaceMan)
+}
+
+func runReplaceMan(cmd *cobra.Command, args []string) (exit int) {
+	if len(args) == 0 {
+		cmd.Usage()
+		return 1
+	}
+	if len(args) != 1 {
+		stderr("replace-manifest: incorrect number of arguments")
+		return 1
+	}
+
+	if debug {
+		stderr("Replacing manifest in ACI with the manifest at ", args[0])
+	}
+
+	err := newACBuild().ReplaceManifest(args[0])
+
+	if err != nil {
+		stderr("replace-manifest: %v", err)
+		return 1
+	}
+
+	return 0
+}

--- a/lib/replace-manifest.go
+++ b/lib/replace-manifest.go
@@ -1,0 +1,71 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lib
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/aci"
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/schema"
+)
+
+// ReplaceManifest will replace the manifest in the expanded ACI stored at
+// a.CurrentACIPath with the new manifest stored at manifestPath
+func (a *ACBuild) ReplaceManifest(manifestPath string) (err error) {
+	if err = a.lock(); err != nil {
+		return err
+	}
+	defer func() {
+		if err1 := a.unlock(); err == nil {
+			err = err1
+		}
+	}()
+
+	finfo, err := os.Stat(manifestPath)
+	switch {
+	case os.IsNotExist(err):
+		return fmt.Errorf("no such file or directory: %s", manifestPath)
+	case err != nil:
+		return err
+	case finfo.IsDir():
+		return fmt.Errorf("%s is a directory", manifestPath)
+	default:
+		break
+	}
+
+	manblob, err := ioutil.ReadFile(manifestPath)
+	if err != nil {
+		return err
+	}
+
+	// Marshal and Unmarshal the manifest to assert that it's valid and to
+	// strip any whitespace
+
+	var man schema.ImageManifest
+	err = man.UnmarshalJSON(manblob)
+	if err != nil {
+		return err
+	}
+
+	manblob, err = man.MarshalJSON()
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(path.Join(a.CurrentACIPath, aci.ManifestFile), manblob, 0755)
+}


### PR DESCRIPTION
`replace-manifest` will overwrite the manifest in the current ACI with a given new ACI. Analogous to `actool`'s `patch-manifest --manifest=thing`