### PR TITLE
begin: populate the arch and os labels when starting with empty ACI

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,15 @@ The following commands are supported:
 
   Sets the exec command in the ACI's manifest.
 
+### Default labels when starting with an empty ACI
+
+When `acbuild begin` isn't passed any arguments a minimal container is created.
+The rootfs is empty, there isn't an exec statement, there's just a placeholder
+name for the image, and so on. There will, however, be two labels created: the
+"os" and "arch" labels. These labels are populated based on the system's
+operating system and architecture, but they can always be overridden or removed
+during the build with the `label add` and `label remove` commands.
+
 ### acbuild run
 
 `acbuild run` builds the root filesystem with any dependencies the ACI has

--- a/lib/begin.go
+++ b/lib/begin.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"runtime"
 	"strings"
 
 	"github.com/appc/acbuild/registry"
@@ -79,6 +80,16 @@ func (a *ACBuild) Begin(start string, insecure bool) (err error) {
 		return err
 	}
 
+	archlabel, err := types.NewACIdentifier("arch")
+	if err != nil {
+		return err
+	}
+
+	oslabel, err := types.NewACIdentifier("os")
+	if err != nil {
+		return err
+	}
+
 	manifest := &schema.ImageManifest{
 		ACKind:    schema.ImageManifestKind,
 		ACVersion: schema.AppContainerVersion,
@@ -87,6 +98,16 @@ func (a *ACBuild) Begin(start string, insecure bool) (err error) {
 			Exec:  nil,
 			User:  "0",
 			Group: "0",
+		},
+		Labels: types.Labels{
+			types.Label{
+				*archlabel,
+				runtime.GOARCH,
+			},
+			types.Label{
+				*oslabel,
+				runtime.GOOS,
+			},
 		},
 	}
 

--- a/registry/fetch.go
+++ b/registry/fetch.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"runtime"
 	"time"
 
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/aci"
@@ -35,11 +36,6 @@ import (
 	"github.com/appc/acbuild/Godeps/_workspace/src/xi2.org/x/xz"
 
 	"github.com/appc/acbuild/util"
-)
-
-var (
-	defaultArch = "amd64"
-	defaultOS   = "linux"
 )
 
 func (r Registry) tmppath() string {
@@ -327,10 +323,10 @@ func (r Registry) discoverEndpoint(imageName types.ACIdentifier, labels types.La
 		return nil, err
 	}
 	if _, ok := app.Labels["arch"]; !ok {
-		app.Labels["arch"] = defaultArch
+		app.Labels["arch"] = runtime.GOARCH
 	}
 	if _, ok := app.Labels["os"]; !ok {
-		app.Labels["os"] = defaultOS
+		app.Labels["os"] = runtime.GOOS
 	}
 
 	eps, attempts, err := discovery.DiscoverEndpoints(*app, r.Insecure)


### PR DESCRIPTION
When beginning a build with an empty ACI, use the runtime package to
populate the arch and os labels of the manifest.