### PR TITLE
help: refactored and rewrote code to generate help page

### DIFF
--- a/acbuild/annotation.go
+++ b/acbuild/annotation.go
@@ -20,9 +20,8 @@ import (
 
 var (
 	cmdAnno = &cobra.Command{
-		Use:     "annotation [command]",
-		Aliases: []string{"anno"},
-		Short:   "Manage annotations",
+		Use:   "annotation [command]",
+		Short: "Manage annotations",
 	}
 	cmdAddAnno = &cobra.Command{
 		Use:     "add NAME VALUE",

--- a/acbuild/dependency.go
+++ b/acbuild/dependency.go
@@ -27,9 +27,8 @@ var (
 	labels  labellist
 	size    uint
 	cmdDep  = &cobra.Command{
-		Use:     "dependency [command]",
-		Aliases: []string{"dep"},
-		Short:   "Manage dependencies",
+		Use:   "dependency [command]",
+		Short: "Manage dependencies",
 	}
 	cmdAddDep = &cobra.Command{
 		Use:     "add IMAGE_NAME",

--- a/acbuild/environment.go
+++ b/acbuild/environment.go
@@ -20,9 +20,8 @@ import (
 
 var (
 	cmdEnv = &cobra.Command{
-		Use:     "environment [command]",
-		Aliases: []string{"env"},
-		Short:   "Manage environment variables",
+		Use:   "environment [command]",
+		Short: "Manage environment variables",
 	}
 	cmdAddEnv = &cobra.Command{
 		Use:     "add NAME VALUE",

--- a/acbuild/set-name.go
+++ b/acbuild/set-name.go
@@ -21,8 +21,8 @@ import (
 var (
 	cmdSetName = &cobra.Command{
 		Use:     "set-name ACI_NAME",
-		Short:   "Change an ACI's name",
-		Long:    "Changes the name of an ACI in its manifest",
+		Short:   "Set the image name",
+		Long:    "Sets the name of the ACI in the manifest",
 		Example: "acbuild name quay.io/coreos/etcd",
 		Run:     runWrapper(runSetName),
 	}


### PR DESCRIPTION
Simplified the code used in generating the help page. Template is
shorter, and has much fewer things passed into it. Combined all
add/remove command pairs.

New help output looks like this:
```
NAME:
        acbuild - the application container build system

USAGE:
        acbuild [command]

COMMANDS:
        annotation [add|remove]         Manage annotations
        begin                           Start a new build
        copy                            Copy a file or directory into an ACI
        dependency [add|remove]         Manage dependencies
        end                             end a current build
        environment [add|remove]        Manage environment variables
        label [add|remove]              Manage labels
        mount [add|remove]              Manage mount points
        port [add|remove]               Manage ports
        replace-manifest                Replace the manifest in the current build
        run                             Run a command in an ACI
        set-exec                        Set the exec command
        set-group                       Set the group
        set-name                        Set the image name
        set-user                        Set the user
        version                         Get the version of acbuild
        write                           Write the ACI to a file
        help                            Help about any command

OPTIONS:
      --debug=false: Print out debug information to stderr
  -h, --help=false: help for acbuild
      --modify="": Path to an ACI to modify (ignores build context)
      --work-path=".": Path to place working files in
```