### PR TITLE
isolators: added commands to add and remove isolators

### DIFF
--- a/acbuild/isolator.go
+++ b/acbuild/isolator.go
@@ -1,0 +1,119 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/spf13/cobra"
+)
+
+var (
+	cmdIso = &cobra.Command{
+		Use:   "isolator [command]",
+		Short: "Manage isolators",
+	}
+	cmdAddIso = &cobra.Command{
+		Use:     "add NAME JSON_FILE",
+		Short:   "Add an isolator",
+		Long:    "Updates the ACI to contain an isolator with the given name and value. If the isolator exists, its value will be changed.",
+		Example: "acbuild isolator add resource/cpu ./value.json",
+		Run:     runWrapper(runAddIso),
+	}
+	cmdRmIso = &cobra.Command{
+		Use:     "remove NAME",
+		Aliases: []string{"rm"},
+		Short:   "Remove an isolator",
+		Long:    "Updates the current ACI's manifest to not contain the given isolator",
+		Example: "acbuild isolator remove resource/memory",
+		Run:     runWrapper(runRemoveIso),
+	}
+)
+
+func init() {
+	cmdAcbuild.AddCommand(cmdIso)
+	cmdIso.AddCommand(cmdAddIso)
+	cmdIso.AddCommand(cmdRmIso)
+}
+
+func runAddIso(cmd *cobra.Command, args []string) (exit int) {
+	if len(args) == 0 {
+		cmd.Usage()
+		return 1
+	}
+	if len(args) != 2 {
+		stderr("isolator add: incorrect number of arguments")
+		return 1
+	}
+
+	var r io.Reader
+	var err error
+	if args[1] == "-" {
+		r = os.Stdin
+	} else {
+		file, err := os.Open(args[1])
+		if err != nil {
+			stderr("isolator add: %v", err)
+			return 1
+		}
+		defer file.Close()
+		r = file
+	}
+
+	val, err := ioutil.ReadAll(r)
+	if err != nil {
+		stderr("isolator add: %v", err)
+		return 1
+	}
+
+	if debug {
+		stderr("Adding isolator %q=%q", args[0], string(val))
+	}
+
+	err = newACBuild().AddIsolator(args[0], val)
+
+	if err != nil {
+		stderr("isolator add: %v", err)
+		return 1
+	}
+
+	return 0
+}
+
+func runRemoveIso(cmd *cobra.Command, args []string) (exit int) {
+	if len(args) == 0 {
+		cmd.Usage()
+		return 1
+	}
+	if len(args) > 1 {
+		stderr("isolator remove: incorrect number of arguments")
+		return 1
+	}
+
+	if debug {
+		stderr("Removing isolator %q", args[0])
+	}
+
+	err := newACBuild().RemoveIsolator(args[0])
+
+	if err != nil {
+		stderr("isolator remove: %v", err)
+		return 1
+	}
+
+	return 0
+}

--- a/lib/isolator.go
+++ b/lib/isolator.go
@@ -1,0 +1,84 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lib
+
+import (
+	"encoding/json"
+
+	"github.com/appc/acbuild/util"
+
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/schema"
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+)
+
+func removeIsolatorFromMan(name types.ACIdentifier) func(*schema.ImageManifest) {
+	return func(s *schema.ImageManifest) {
+		if s.App == nil {
+			return
+		}
+		for i := len(s.App.Isolators) - 1; i >= 0; i-- {
+			if s.App.Isolators[i].Name == name {
+				s.App.Isolators = append(
+					s.App.Isolators[:i],
+					s.App.Isolators[i+1:]...)
+			}
+		}
+	}
+}
+
+func (a *ACBuild) AddIsolator(name string, value []byte) (err error) {
+	if err = a.lock(); err != nil {
+		return err
+	}
+	defer func() {
+		if err1 := a.unlock(); err == nil {
+			err = err1
+		}
+	}()
+
+	acid, err := types.NewACIdentifier(name)
+	if err != nil {
+		return err
+	}
+	rawMsg := json.RawMessage(value)
+
+	fn := func(s *schema.ImageManifest) {
+		removeIsolatorFromMan(*acid)(s)
+		s.App.Isolators = append(s.App.Isolators,
+			types.Isolator{
+				Name:     *acid,
+				ValueRaw: &rawMsg,
+			})
+	}
+	return util.ModifyManifest(fn, a.CurrentACIPath)
+}
+
+func (a *ACBuild) RemoveIsolator(name string) (err error) {
+	if err = a.lock(); err != nil {
+		return err
+	}
+	defer func() {
+		if err1 := a.unlock(); err == nil {
+			err = err1
+		}
+	}()
+
+	acid, err := types.NewACIdentifier(name)
+	if err != nil {
+		return err
+	}
+
+	return util.ModifyManifest(removeIsolatorFromMan(*acid), a.CurrentACIPath)
+}


### PR DESCRIPTION
Fixes https://github.com/appc/acbuild/issues/42.

Example commands:
```
acbuild isolator add resource/cpu value.json
echo '{"request":"1G","limit":"2G"}' | acbuild isolator add resource/memory -
```