### PR TITLE
travis: added .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: go
+matrix:
+  include:
+    - go: 1.4.2
+    - go: 1.5.1
+
+script:
+ - ./build
+ - ./test
+
+notifications:
+  email: false
+
+sudo: true


### PR DESCRIPTION
Added a `.travis.yml` file to allow for travis CI to run.

Required a modification to `tests/common.go` to work in the travis environment.