### PR TITLE
util: extracting ACIs no longer requires root

### DIFF
--- a/lib/run.go
+++ b/lib/run.go
@@ -47,6 +47,10 @@ func (a *ACBuild) Run(cmd []string, insecure bool) (err error) {
 		}
 	}()
 
+	if os.Geteuid() != 0 {
+		return fmt.Errorf("the run subcommand must be run as root")
+	}
+
 	err = util.RmAndMkdir(a.OverlayTargetPath)
 	if err != nil {
 		return err


### PR DESCRIPTION
Modified the ExtractImage function in the util package to use the new
ExtractTarInsecure function when not running as root.

Also added a check to run for the current user to be root, so that a
nicer error message can be printed.