### PR TITLE
*: many places were generating an invalid App struct

### DIFF
--- a/lib/begin.go
+++ b/lib/begin.go
@@ -94,11 +94,6 @@ func (a *ACBuild) Begin(start string, insecure bool) (err error) {
 		ACKind:    schema.ImageManifestKind,
 		ACVersion: schema.AppContainerVersion,
 		Name:      *acid,
-		App: &types.App{
-			Exec:  nil,
-			User:  "0",
-			Group: "0",
-		},
 		Labels: types.Labels{
 			types.Label{
 				*archlabel,

--- a/lib/common.go
+++ b/lib/common.go
@@ -20,14 +20,26 @@ import (
 	"path"
 	"syscall"
 
+	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+
 	"github.com/appc/acbuild/util"
 )
 
 const defaultWorkPath = ".acbuild"
 
-// ErrNotFound is returned when acbuild is asked to remove an element from
-// a list and the element is not present in the list
+// ErrNotFound is returned when acbuild is asked to remove an element from a
+// list and the element is not present in the list
 var ErrNotFound = fmt.Errorf("element to be removed does not exist in this ACI")
+
+// newManifestApp will generate a valid minimal types.App for use in a
+// schema.ImageManifest. This is necessary as placing a completely empty
+// types.App into a manifest will result in an invalid manifest.
+func newManifestApp() *types.App {
+	return &types.App{
+		User:  "0",
+		Group: "0",
+	}
+}
 
 // ACBuild contains all the information for a current build. Once an ACBuild
 // has been created, the functions available on it will perform different

--- a/lib/env.go
+++ b/lib/env.go
@@ -18,13 +18,12 @@ import (
 	"github.com/appc/acbuild/util"
 
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/schema"
-	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 )
 
 func removeFromEnv(name string) func(*schema.ImageManifest) error {
 	return func(s *schema.ImageManifest) error {
 		if s.App == nil {
-			return nil
+			return ErrNotFound
 		}
 		foundOne := false
 		for i := len(s.App.Environment) - 1; i >= 0; i-- {
@@ -57,7 +56,7 @@ func (a *ACBuild) AddEnv(name, value string) (err error) {
 
 	fn := func(s *schema.ImageManifest) error {
 		if s.App == nil {
-			s.App = &types.App{}
+			s.App = newManifestApp()
 		}
 		s.App.Environment.Set(name, value)
 		return nil

--- a/lib/isolator.go
+++ b/lib/isolator.go
@@ -26,7 +26,7 @@ import (
 func removeIsolatorFromMan(name types.ACIdentifier) func(*schema.ImageManifest) error {
 	return func(s *schema.ImageManifest) error {
 		if s.App == nil {
-			return nil
+			return ErrNotFound
 		}
 		foundOne := false
 		for i := len(s.App.Isolators) - 1; i >= 0; i-- {
@@ -61,6 +61,9 @@ func (a *ACBuild) AddIsolator(name string, value []byte) (err error) {
 	rawMsg := json.RawMessage(value)
 
 	fn := func(s *schema.ImageManifest) error {
+		if s.App == nil {
+			s.App = newManifestApp()
+		}
 		removeIsolatorFromMan(*acid)(s)
 		s.App.Isolators = append(s.App.Isolators,
 			types.Isolator{

--- a/lib/mounts.go
+++ b/lib/mounts.go
@@ -24,7 +24,7 @@ import (
 func removeMount(name types.ACName) func(*schema.ImageManifest) error {
 	return func(s *schema.ImageManifest) error {
 		if s.App == nil {
-			return nil
+			return ErrNotFound
 		}
 		foundOne := false
 		for i := len(s.App.MountPoints) - 1; i >= 0; i-- {
@@ -64,7 +64,7 @@ func (a *ACBuild) AddMount(name, path string, readOnly bool) (err error) {
 	fn := func(s *schema.ImageManifest) error {
 		removeMount(*acn)(s)
 		if s.App == nil {
-			s.App = &types.App{}
+			s.App = newManifestApp()
 		}
 		s.App.MountPoints = append(s.App.MountPoints,
 			types.MountPoint{

--- a/lib/port.go
+++ b/lib/port.go
@@ -24,7 +24,7 @@ import (
 func removePort(name types.ACName) func(*schema.ImageManifest) error {
 	return func(s *schema.ImageManifest) error {
 		if s.App == nil {
-			return nil
+			return ErrNotFound
 		}
 		foundOne := false
 		for i := len(s.App.Ports) - 1; i >= 0; i-- {
@@ -62,10 +62,10 @@ func (a *ACBuild) AddPort(name, protocol string, port, count uint, socketActivat
 	}
 
 	fn := func(s *schema.ImageManifest) error {
-		removePort(*acn)(s)
 		if s.App == nil {
-			s.App = &types.App{}
+			s.App = newManifestApp()
 		}
+		removePort(*acn)(s)
 		s.App.Ports = append(s.App.Ports,
 			types.Port{
 				Name:            *acn,

--- a/lib/set-event-handlers.go
+++ b/lib/set-event-handlers.go
@@ -51,7 +51,7 @@ func (a *ACBuild) setEventHandler(name string, exec []string) (err error) {
 	fn := func(s *schema.ImageManifest) error {
 		removeEventHandler(name, s)
 		if s.App == nil {
-			s.App = &types.App{}
+			s.App = newManifestApp()
 		}
 		s.App.EventHandlers = append(s.App.EventHandlers,
 			types.EventHandler{

--- a/lib/set-exec.go
+++ b/lib/set-exec.go
@@ -18,7 +18,6 @@ import (
 	"github.com/appc/acbuild/util"
 
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/schema"
-	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 )
 
 // SetExec sets the exec command for the untarred ACI stored at
@@ -35,7 +34,7 @@ func (a *ACBuild) SetExec(cmd []string) (err error) {
 
 	fn := func(s *schema.ImageManifest) error {
 		if s.App == nil {
-			s.App = &types.App{}
+			s.App = newManifestApp()
 		}
 		s.App.Exec = cmd
 		return nil

--- a/lib/set-group.go
+++ b/lib/set-group.go
@@ -20,7 +20,6 @@ import (
 	"github.com/appc/acbuild/util"
 
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/schema"
-	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 )
 
 // SetGroup sets the group the pod will run as in the untarred ACI stored at
@@ -40,7 +39,7 @@ func (a *ACBuild) SetGroup(group string) (err error) {
 	}
 	fn := func(s *schema.ImageManifest) error {
 		if s.App == nil {
-			s.App = &types.App{}
+			s.App = newManifestApp()
 		}
 		s.App.Group = group
 		return nil

--- a/lib/set-user.go
+++ b/lib/set-user.go
@@ -20,7 +20,6 @@ import (
 	"github.com/appc/acbuild/util"
 
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/schema"
-	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 )
 
 // SetUser sets the user the pod will run as in the untarred ACI stored at
@@ -40,7 +39,7 @@ func (a *ACBuild) SetUser(user string) (err error) {
 	}
 	fn := func(s *schema.ImageManifest) error {
 		if s.App == nil {
-			s.App = &types.App{}
+			s.App = newManifestApp()
 		}
 		s.App.User = user
 		return nil

--- a/lib/set-working-dir.go
+++ b/lib/set-working-dir.go
@@ -18,7 +18,6 @@ import (
 	"github.com/appc/acbuild/util"
 
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/schema"
-	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 )
 
 // SetWorkingDir sets the workingDirectory value in the untarred ACI stored at
@@ -35,7 +34,7 @@ func (a *ACBuild) SetWorkingDir(dir string) (err error) {
 
 	fn := func(s *schema.ImageManifest) error {
 		if s.App == nil {
-			s.App = &types.App{}
+			s.App = newManifestApp()
 		}
 		s.App.WorkingDirectory = dir
 		return nil

--- a/tests/annotation_test.go
+++ b/tests/annotation_test.go
@@ -30,11 +30,6 @@ var manWithOneAnno = schema.ImageManifest{
 	ACKind:    schema.ImageManifestKind,
 	ACVersion: schema.AppContainerVersion,
 	Name:      *types.MustACIdentifier("acbuild-unnamed"),
-	App: &types.App{
-		Exec:  nil,
-		User:  "0",
-		Group: "0",
-	},
 	Annotations: types.Annotations{
 		types.Annotation{
 			Name:  *types.MustACIdentifier(annoName),

--- a/tests/common.go
+++ b/tests/common.go
@@ -49,6 +49,13 @@ var (
 		ACKind:    schema.ImageManifestKind,
 		ACVersion: schema.AppContainerVersion,
 		Name:      *types.MustACIdentifier("acbuild-unnamed"),
+		Labels:    systemLabels,
+	}
+
+	emptyManifestWithApp = schema.ImageManifest{
+		ACKind:    schema.ImageManifestKind,
+		ACVersion: schema.AppContainerVersion,
+		Name:      *types.MustACIdentifier("acbuild-unnamed"),
 		App: &types.App{
 			Exec:  nil,
 			User:  "0",

--- a/tests/dependency_test.go
+++ b/tests/dependency_test.go
@@ -40,14 +40,9 @@ func newLabel(key, val string) string {
 
 func manWithDeps(deps types.Dependencies) schema.ImageManifest {
 	return schema.ImageManifest{
-		ACKind:    schema.ImageManifestKind,
-		ACVersion: schema.AppContainerVersion,
-		Name:      *types.MustACIdentifier("acbuild-unnamed"),
-		App: &types.App{
-			Exec:  nil,
-			User:  "0",
-			Group: "0",
-		},
+		ACKind:       schema.ImageManifestKind,
+		ACVersion:    schema.AppContainerVersion,
+		Name:         *types.MustACIdentifier("acbuild-unnamed"),
 		Dependencies: deps,
 		Labels:       systemLabels,
 	}

--- a/tests/environment_test.go
+++ b/tests/environment_test.go
@@ -162,7 +162,7 @@ func TestAddRmEnv(t *testing.T) {
 		t.Fatalf("%v\n", err)
 	}
 
-	checkManifest(t, workingDir, emptyManifest)
+	checkManifest(t, workingDir, emptyManifestWithApp)
 	checkEmptyRootfs(t, workingDir)
 }
 

--- a/tests/label_test.go
+++ b/tests/label_test.go
@@ -34,12 +34,7 @@ func manWithLabels(labels types.Labels) schema.ImageManifest {
 		ACKind:    schema.ImageManifestKind,
 		ACVersion: schema.AppContainerVersion,
 		Name:      *types.MustACIdentifier("acbuild-unnamed"),
-		App: &types.App{
-			Exec:  nil,
-			User:  "0",
-			Group: "0",
-		},
-		Labels: append(systemLabels, labels...),
+		Labels:    append(systemLabels, labels...),
 	}
 }
 

--- a/tests/mount_test.go
+++ b/tests/mount_test.go
@@ -159,7 +159,7 @@ func TestAddRmMount(t *testing.T) {
 		t.Fatalf("%v\n", err)
 	}
 
-	checkManifest(t, workingDir, emptyManifest)
+	checkManifest(t, workingDir, emptyManifestWithApp)
 	checkEmptyRootfs(t, workingDir)
 }
 

--- a/tests/port_test.go
+++ b/tests/port_test.go
@@ -191,7 +191,7 @@ func TestAddRmPorts(t *testing.T) {
 		t.Fatalf("%v\n", err)
 	}
 
-	checkManifest(t, workingDir, emptyManifest)
+	checkManifest(t, workingDir, emptyManifestWithApp)
 	checkEmptyRootfs(t, workingDir)
 }
 

--- a/tests/set-name_test.go
+++ b/tests/set-name_test.go
@@ -35,12 +35,7 @@ func TestSetName(t *testing.T) {
 		ACKind:    schema.ImageManifestKind,
 		ACVersion: schema.AppContainerVersion,
 		Name:      *types.MustACIdentifier(name),
-		App: &types.App{
-			Exec:  nil,
-			User:  "0",
-			Group: "0",
-		},
-		Labels: systemLabels,
+		Labels:    systemLabels,
 	}
 
 	checkManifest(t, workingDir, man)


### PR DESCRIPTION
When presented with a manifest that lacked an App, many places in the
lib package would fill it in with a `&types.App{}`. This is incorrect, as
the user and group fields must be set in the struct for the manifest to
be valid. Without this fix, acbuild will error when asked to modify an
existing ACI in such a way that requires creating an App in the
manifest.