### PR TITLE
docs: refactored README into Documentation directory

### DIFF
--- a/Documentation/bash-scripts.md
+++ b/Documentation/bash-scripts.md
@@ -1,0 +1,39 @@
+# Bash scripts
+
+Bash scripting provides a common, simple, and well-known mechanism to drive
+`acbuild`. A script template, below, is used for the examples in this
+repository. It makes working with acbuild a little nicer by exiting the script
+when it hits an error, and calling `acbuild end` whenever the script exits.
+
+Since the script leverages `bash` features, we open it by specifying execution
+in the bash shell, rather than just inheriting the user's `SHELL` environment.
+
+Further, we set the `-e` option to bash to ensure that the entire script exits
+on the failure of any command. This gives us some atomicity, ensuring that
+either a complete and valid ACI is constructed, or none at all
+
+The `begin` line starts the build. If the build is to be started from an
+existing ACI, this line will be different.
+
+The rest of the script is concerned with cleanup and error handling. The
+`acbuildend` function is interesting, as it serves as a simple "catch" mechanism
+for the script, called on a trap triggered by either reaching the script's end,
+or by a non-zero return value from any command in the script. `acibuildend`
+stores the last command's exit code, then calls `acbuild --debug end` to
+terminate the build, passing the exit code, if any, through the script exit, to
+help with troubleshooting.
+
+```bash
+#!/usr/bin/env bash
+set -e
+
+acbuildend () {
+    export EXIT=$?;
+    acbuild --debug end && exit $EXIT;
+}
+
+acbuild --debug begin
+trap acbuildend EXIT
+
+# User entered acbuild commands go here
+```

--- a/Documentation/context-free-mode.md
+++ b/Documentation/context-free-mode.md
@@ -1,0 +1,19 @@
+# Context Free Mode
+
+If a tiny change is to be made to an ACI, for example if the name needs to be
+changed, it can be cumbersome to call `begin`, `write`, and `end` for the
+single change.
+
+To make this use case more streamlined, the `--modify` flag exists. When a
+command is invoked with this flag acbuild will create a directory in `/tmp` to
+store the build context, and do the following with this alternate context:
+
+- Call `acbuild begin` with the ACI passed in via the `--modify` flag.
+- Call the provided command.
+- Call `acbuild write --overwrite` with the ACI passed in via the `--modify`
+  flag.
+- Call `acbuild end`.
+
+If more than one change needs to be made, it will be faster to avoid this flag,
+as it will result in unnecessary compressing/uncompressing and copying between
+the changes.

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -1,0 +1,143 @@
+# Getting Started with acbuild
+
+acbuild aims to support a workflow very similar to `Dockerfile`s, but with more
+flexibility and adherence to the Unix tools philosophy, and native image output
+in the modern ACI format. Generally, the workflow consists of a shell script
+(analogous to the `Dockerfile`) driving acbuild to construct an ACI, either
+from scratch or with another image as a base. This ACI is then stored in an
+_image registry_, and fetched by users to execute the applications stored
+within.
+
+The following guide will walk you through building and running a simple ACI
+with acbuild. The ACI will contain nginx, and will serve static files over HTTP.
+
+Note that some of the commands shown here must be run as root.
+
+## Making the ACI
+
+### Starting the build
+
+All acbuilds happen within a _context_. This build context is explicitly
+created at `acbuild begin`, and deleted at build completion with `acbuild end`.
+By default, the context and build are stored in the current working directory.
+
+This means that if you change directories in the middle of a build, acbuild will
+forget everything about the current build until you go back to the directory
+the build was started in. If that's an issue, you can override this with the
+`--work-path` flag, which will use the provided directory to store and access
+build information instead of the current directory.
+
+The command to start the build is:
+
+```bash
+acbuild begin
+```
+
+When `begin` isn't passed any arguments the build starts with an empty ACI.
+acbuild can also use an existing ACI as the starting point for the build.  More
+information on this feature is in the documentation for `begin`.
+
+### Naming the ACI
+
+All ACIs must be named. When a build is started with an empty ACI acbuild
+actually gives your ACI a placeholder name, and it won't let you write out an
+ACI until you change it away from that. If you're going to host this ACI
+somewhere the name should match the name used during meta discovery to find the
+download URL. For this example we'll just be running it off of the local
+filesystem, so name it whatever you want.
+
+```bash
+acbuild set-name example.com/nginx
+```
+
+For more information on meta discovery, check out the [appc
+spec](https://github.com/appc/spec/blob/master/spec/discovery.md#meta-discovery).
+
+### Adding a dependency
+
+Having an empty ACI isn't all that useful, so let's add a dependency.
+
+```bash
+acbuild dependency add quay.io/coreos/alpine-sh
+```
+
+Now when this ACI gets run the image at `quay.io/coreos/alpine-sh` will be
+fetched, and used as a base for our image. This means that our ACI only needs
+to contain the files that we add or modify on top of alpine.
+
+### Installing nginx
+
+Now that we've got a base image with fancy things like a shell and a package
+manager, let's install nginx.
+
+```bash
+acbuild run -- apk update
+acbuild run -- apk add nginx
+```
+
+The first command updates alpine's package manager, and the second command
+fetches and installs nginx. The `--` in each command stops acbuild from trying
+to parse flags that occur after the `--`. They're not necessary in this
+instance, but they would be if one of our commands had any arguments that began
+with a `-`.
+
+### Adding a mount point
+
+Since the goal of this is to host a static website, we're going to add a mount
+point to the default location that nginx serves files out of. This can be used
+when the ACI is run to make a directory on the host available inside of the
+container.
+
+```bash
+acbuild mount add html /usr/share/nginx/html
+```
+
+### Setting the exec statement
+
+The last thing we need to set in our ACI is the executable we want it to run.
+Without this command, the ACI couldn't be used without specifying a path to an
+executable inside of it at runtime.
+
+```bash
+acbuild set-exec -- /usr/sbin/nginx -g "daemon off;"
+```
+
+The `--` argument serves the same purpose here as it did when we were using the
+`run` command, except it actually matters this time. Without it, acbuild would
+think that the `-g` argument was a flag for it, instead of something to pass to
+`/usr/sbin/nginx` when the ACI is run.
+
+### Writing out the ACI
+
+With that, our ACI is complete. Before ending the build however, we need to
+write out the ACI to a file.
+
+```bash
+acbuild write nginx.aci
+```
+
+### Ending the build
+
+This command will delete our current build context. Had we not written out an
+ACI, everything we've done up to this point would be lost.
+
+```bash
+acbuild end
+```
+
+## Using the ACI
+
+If you have a directory with some files for nginx to serve...
+
+```bash
+mkdir test
+echo "Hello, world!" > test/index.html
+```
+
+... using the ACI is something as simple as the following command:
+
+```bash
+rkt run --insecure-skip-verify ./nginx.aci --volume html,kind=host,source=/path/to/test --net=host
+```
+
+Now point your browser at [`http://localhost`](http://localhost).

--- a/Documentation/subcommands/annotation.md
+++ b/Documentation/subcommands/annotation.md
@@ -1,0 +1,36 @@
+# acbuild annotation
+
+Annotations are elements in an ACI's manifest that store extra metadata about
+the image. Each annotation has two parts: a key and a value. Each annotation
+key is unique for a given manifest. Annotations may be read by external tooling
+(like a registry) to get additional information about an ACI.
+
+## Subcommands
+
+* `acbuild annotation add NAME VALUE`
+
+  Updates the ACI to contain an annotation with the given name and value. If the
+  annotation already exists, its value will be changed.
+
+* `acbuild annotation remove NAME`
+
+  Removes the annotation with the given name from the ACI.
+
+## Common annotations
+
+Common annotations include:
+
+- `created`: date on which the image was built.
+- `authors`: contact details of the creators responsible for the image.
+- `homepage`: URL to find more information about the image.
+- `documentation`: URL to get documentation on the image.
+
+## Examples
+
+```bash
+acbuild annotation add documentation https://example.com/docs
+
+acbuild annotation add authors "Carly Container <carly@example.com>, Nat Network <[nat@example.com](mailto:nat@example.com)>"
+
+acbuild annotation remove homepage
+```

--- a/Documentation/subcommands/begin.md
+++ b/Documentation/subcommands/begin.md
@@ -1,0 +1,55 @@
+# acbuild begin
+
+`acbuild begin` will start a new build.
+
+## Location of work context
+
+By default, information about the build is stored at `.acbuild` in the current
+working directory. If the current directory changes during the build, `acbuild`
+will be unaware of, and unable to operate on, the build that was started until
+the current directory is changed back to the location where `acbuild begin` was
+run. If this is undesirable, the `--work-path` flag can be provided to specify
+the location to store and access the build context.
+
+## Starting state
+
+The build will default to starting with an empty ACI. The rootfs will be empty,
+and the manifest will look something like the following:
+
+```json
+{
+    "acKind": "ImageManifest",
+    "acVersion": "0.7.1+git",
+    "name": "acbuild-unnamed",
+    "labels": [
+        {
+            "name": "arch",
+            "value": "amd64"
+        },
+        {
+            "name": "os",
+            "value": "linux"
+        }
+    ]
+}
+```
+
+The `arch` and `os` labels are filled in with the architecture and operating
+system of the machine acbuild is running on. If this is undesirable, the labels
+can be modified or removed with the `acbuild label` command.
+
+The begin command can also be passed an ACI, either on the file system or an
+image name to fetch via [meta
+discovery](https://github.com/appc/spec/blob/master/spec/discovery.md#meta-discovery).
+When an ACI is specified, it is used as the starting point for the build as
+opposed to an empty image. If the image is to be fetched via meta discovery
+over http (as opposed to https), the `--insecure` flag must be used.
+
+## Examples
+
+```bash
+acbuild begin
+acbuild begin ./my-app.aci
+acbuild begin quay.io/coreos/alpine-sh
+acbuild --work-path /tmp/mybuild begin
+```

--- a/Documentation/subcommands/copy.md
+++ b/Documentation/subcommands/copy.md
@@ -1,0 +1,15 @@
+# acbuild copy
+
+`acbuild copy` will copy a file or directory from the local filesystem into the
+ACI. The first argument is the path on the local system to copy from, and the
+second argument is the path inside the ACI to copy to.
+
+The following two commands should do the same thing:
+
+```bash
+acbuild copy ./nginx.conf /etc/nginx/nginx.conf
+```
+
+```bash
+cp ./nginx.conf ./.acbuild/currentaci/rootfs/etc/nginx/nginx.conf
+```

--- a/Documentation/subcommands/dependency.md
+++ b/Documentation/subcommands/dependency.md
@@ -1,0 +1,49 @@
+# acbuild dependency
+
+Dependencies are ACIs separate from the current ACI, that are placed down into
+the rootfs before the files from the current ACI.
+
+The ordering of an ACI's dependencies is significant. Let's say the current ACI
+has two dependencies, A and B, where A comes before B. If both A and B contain
+the file `/bin/sh`, and the current ACI does not have this file, then the
+`/bin/sh` from B is what will appear in the container when it is run.
+
+At the time of writing acbuild simply puts the dependency in the manifest in
+the order they were added. If the ordering of an ACI's dependencies is
+incorrect, the user must remove each dependency manually and then add them in
+the correct order.
+
+## Subcommands
+
+* `acbuild dependency add IMAGE_NAME`
+
+  Updates the ACI to contain a dependency with the given name.
+
+* `acbuild dependency remove IMAGE_NAME`
+
+  Removes the dependency with the given image name from the ACI.
+
+## Flags
+
+The `add` command also has the following optional flags:
+
+- `--image-id`: sets the content hash of the dependency being added. When this
+  ACI is run, the retrieved dependency must match this hash.
+
+- `--label`: adds a label to the dependency being added. This is used when
+  determining which image to fetch for the dependency.
+
+- `--size`: the size of the dependency being added, in bytes. When this ACI is
+  run, the retrieved dependency must have this size.
+
+## Examples
+
+```bash
+acbuild dependency add example.com/alpine
+
+acbuild dependency add example.com/ubuntu --image-id sha512-...
+
+acbuild dependency add example.com/nodejs --label version=4.0.0 --label arch=noarch
+
+acbuild dependency remove example.com/centos
+```

--- a/Documentation/subcommands/end.md
+++ b/Documentation/subcommands/end.md
@@ -1,0 +1,9 @@
+# acbuild end
+
+`acbuild end` will end the current build. This is accomplished by simply
+deleting the directory the build context is stored in, which is `.acbuild` in
+either the current directory or the directory specified via the `--work-path`
+flag.
+
+If the build was a success and an ACI is to be produced, the `write` command
+must be called before `end`, otherwise the build will be lost.

--- a/Documentation/subcommands/environment.md
+++ b/Documentation/subcommands/environment.md
@@ -1,0 +1,23 @@
+# acbuild environment
+
+`acbuild environment` is used to set environment variables in the ACI. Each
+variable name must be unique.
+
+## Subcommands
+
+* `acbuild environment add NAME VALUE`
+
+  Updates the ACI to contain an environment variable with the given name and
+  value. If the variable already exists, its value will be changed.
+
+* `acbuild environment remove NAME`
+
+  Removes the environment variable with the given name from the ACI.
+
+## Examples
+
+```bash
+acbuild environment add REDUCE_WORKER_DEBUG true
+
+acbuild environment remove LANG
+```

--- a/Documentation/subcommands/label.md
+++ b/Documentation/subcommands/label.md
@@ -1,0 +1,40 @@
+# acbuild label
+
+Labels are a part of an ACI's manifest that are used during image discovery and
+dependency resolution. Each label has a name and a value, and each name must be
+unique.
+
+## Subcommands
+
+* `acbuild label add NAME VALUE`
+
+  Updates the ACI to contain a label with the given name and value. If the label
+  already exists, its value will be changed.
+
+* `acbuild label remove NAME`
+
+  Removes the label with the given name from the ACI.
+
+## Common Labels
+
+Common labels include:
+
+- `version`: the version of this ACI. Ideally when combined with the current
+  ACI's name this will be unique for every build of an app on a given OS and
+  architecture.
+- `os`: the operating system the ACI is built for.
+- `arch`: the architecture the ACI is built for.
+
+## Default Labels
+
+When an empty ACI is created with `acbuild begin`, by default the `os` and
+`arch` labels are created for you. Their default values are the current
+system's OS and architecture, as determined by golang's `runtime` package.
+
+## Examples
+
+```bash
+acbuild label add version latest
+
+acbuild label rm os
+```

--- a/Documentation/subcommands/mount.md
+++ b/Documentation/subcommands/mount.md
@@ -1,0 +1,30 @@
+# acbuild mount
+
+Mount points can be specified in an ACI's manifest. These are locations withing
+the ACI's rootfs that the app expects to have external data mounted to.
+
+## Subcommands
+
+* `acbuild mount add NAME PATH`
+
+  Updates the ACI to contain a mount point with the given name and path. If the
+  mount point already exists, its path will be changed.
+
+* `acbuild mount remove NAME`
+
+  Removes the mount point with the given name from the ACI.
+
+## Flags
+
+- `--read-only`: when specified, the data mounted into the ACI's rootfs should
+  be mounted as read only.
+
+## Examples
+
+```bash
+acbuild mount add source /root/source
+
+acbuild mount add html /usr/share/nginx/html --read-only
+
+acbuild mount remove work
+```

--- a/Documentation/subcommands/port.md
+++ b/Documentation/subcommands/port.md
@@ -1,0 +1,37 @@
+# acbuild port
+
+Ports can be specified in an ACI's manifest. This allows for easy mapping of
+ports inside the ACI to ports on the host, when the app is run in a separate
+network namespace, among other uses.
+
+## Subcommands
+
+* `acbuild port add NAME PROTOCOL PORT`
+
+  Updates the ACI to contain a port with the given name, protocol, and port.
+  The protocol is either `udp` or `tcp`. If the port already exists, its values
+  will be changed.
+
+* `acbuild port remove NAME`
+
+  Removes the port with the given name from the ACI.
+
+## Flags
+
+`acbuild port add` supports the following flags:
+
+- `--count`: when specified, represents a range of ports as opposed to a single
+  one. The range starts at the port being added, and has a size of the given
+  number.
+- `--socket-activated`: when set, the application expects to be socket
+  activated on the given ports.
+
+## Examples:
+
+```bash
+acbuild port add http tcp 80
+
+acbuild port add dns udp 53
+
+acbuild port remove tftp
+```

--- a/Documentation/subcommands/run.md
+++ b/Documentation/subcommands/run.md
@@ -1,0 +1,27 @@
+# acbuild run
+
+`acbuild run` will run the given command inside the ACI.
+
+## Dependencies
+
+In order to be able to run the command, all dependencies of the current ACI
+must be fetched. The first time `run` is called, the dependencies will be
+downloaded and expanded.
+
+## Overlayfs
+
+acbuild utilizes overlayfs when running a command in an ACI with dependencies.
+This is so that acbuild is able to separate out the files from the dependencies
+and the files in your ACI after the command finishes running.
+
+Obviously this is not necessary when there are no dependencies. If `acbuild
+run` is to be used on a system without overlayfs, the ACI and its dependencies
+must be flattened into a single ACI without dependencies. A command called
+`acbuild squash` is being worked on to do this.
+
+## systmed-nspawn
+
+acbuild currently uses `systemd-nspawn` to run commands inside the ACI. This
+means that the machine running acbuild must have systemd installed to be able
+to use `acbuild run`. Alternate execution tools (like `runc`) will be added in
+the future.

--- a/Documentation/subcommands/set-exec.md
+++ b/Documentation/subcommands/set-exec.md
@@ -1,0 +1,5 @@
+# acbuild set-exec
+
+* `acbuild set-exec CMD [ARGS]`
+
+  Sets the exec command in the ACI's manifest.

--- a/Documentation/subcommands/set-group.md
+++ b/Documentation/subcommands/set-group.md
@@ -1,0 +1,5 @@
+# acbuild set-group
+
+* `acbuild set-group GROUP`
+
+  Set the group the app will run as inside the container.

--- a/Documentation/subcommands/set-name.md
+++ b/Documentation/subcommands/set-name.md
@@ -1,0 +1,5 @@
+# acbuild set-name
+
+* `acbuild set-name ACI_NAME`
+
+  Changes the name of the ACI in its manifest.

--- a/Documentation/subcommands/set-user.md
+++ b/Documentation/subcommands/set-user.md
@@ -1,0 +1,5 @@
+# acbuild set-user
+
+* `acbuild set-user USER`
+  
+  Set the user the app will run as inside the container

--- a/Documentation/subcommands/write.md
+++ b/Documentation/subcommands/write.md
@@ -1,0 +1,43 @@
+# acbuild write
+
+`acbuild write` will produce an ACI from the current build context. This can be
+called an arbitrary number of times during a build, but in most cases it should
+probably be called at least once.
+
+## Writing the image
+
+`acbuild write` requires one argument: the file to write the ACI to. If the
+file exists, acbuild will refuse to overwrite the file unless the `--overwrite`
+flag is used.
+
+## Signing the image
+
+`acbuild write` can exec the `gpg` command on your system to sign the ACI for you. If the `--sign` flag is used without any other arguments like so:
+
+```bash
+acbuild write mycoolapp.aci --sign
+```
+
+acbuild would run the following command after it has finished writing out the
+ACI:
+
+```bash
+gpg --armor --yes --output mycoolapp.aci.asc --detach-sig mycoolapp.aci
+```
+
+If the user who is running acbuild has their gpg keyring configured correctly
+this should Just Work™, but there will be cases where this isn't sufficient. To
+allow the user to have control over the gpg command run, arguments to replace
+the `--armor --yes` flags can be specified after the ACI path.
+
+For example if the user wishes to generate the signature with the following command:
+
+```bash
+gpg --no-default-keyring --armor --secret-keyring ./rkt.sec --keyring ./rkt.pub --output mycoolapp.aci.asc --detach-sig mycoolapp.aci
+```
+
+the acbuild command to do it would be:
+
+```bash
+acbuild write mycoolapp.aci --sign -- --no-default-keyring --armor --secret-keyring ./rkt.sec --keyring ./rkt.pub
+```

--- a/README.md
+++ b/README.md
@@ -8,18 +8,23 @@ acbuild is a command line utility to build and modify App Container Images
 
 ## Rationale
 
-Dockerfiles are powerful and feature useful concepts such as build layers, 
-controlled build environment. At the same time, they lack flexibility 
+Dockerfiles are powerful, and feature useful concepts such as build layers and
+a controlled build environment. At the same time, they lack flexibility 
 (impossible to extend, re-use environment variables) and don't play nicely 
 with the appc spec and Linux toolchain (e.g. shell, makefiles)
 
-`acbuild` is a command-line tool that natively supports ACI builds and integrates 
-well with shell, makefiles and
-other Unix tools.
+`acbuild` is a command-line tool that natively supports ACI builds and
+integrates well with the shell, `Makefile`s, and other Unix tools.
 
 ## Installation
 
-### Runtime dependencies
+### Dependencies
+
+acbuild can only be run on a Linux system, and has only been tested on the
+amd64 architecture.
+
+For trying out acbuild on Mac OS X, it's recommended to use Vagrant.
+Instructions on how to do this are a little further down in this document.
 
 acbuild requires a handful of commands be available on the system on 
 which it's run:
@@ -29,9 +34,15 @@ which it's run:
 - `modprobe`
 - `gpg`
 
+### Prebuilt Binaries
+
+The easiest way to get `acbuild` is to download one of the
+[releases](https://github.com/appc/acbuild/releases) from GitHub.
+
 ### Build from source
 
-Currently the only way to install `acbuild` is to build from source. 
+The other way to get `acbuild` is to build it from source.
+
 Follow these steps to do so:
 
 1. Grab the source code for `acbuild` by `git clone`ing the source repository:
@@ -46,8 +57,8 @@ Follow these steps to do so:
    ./build
    ```
 
-   Or, if you want to build in docker (assuming `$PWD` exists and contains `acbuild/`
-   on your Docker host):
+   Or, if you want to build in docker (assuming `$PWD` exists and contains
+   `acbuild/` on your Docker host):
 
    ```
    cd acbuild
@@ -68,188 +79,31 @@ and put the following lines at the end of the file:
    export PATH=$PATH:$ACBUILD_BIN_DIR
    ```
 
-## Usage
+### Trying out acbuild using Vagrant
 
-A build with `acbuild` is explicitly started with `begin` and finished with
-`end`. While a build is in progress the current ACI is stored expanded in the
-current working directory at `.acbuild.tmp`. A build can be started with an
-empty ACI, or an initial ACI can be provided.
-
-The following commands are supported:
-
-* `acbuild begin [ACI]`
-
-  Begin a build. Optionally an ACI can be specified (either on the filesystem or
-  fetched via meta discovery) as a starting point for the build. If unspecified,
-  an empty ACI will be the starting point.
-
-* `acbuild write ACI_PATH`
-
-  Write an ACI resulting from the current build context to the given path. See
-  the section below on signing ACIs.
-
-* `acbuild end`
-
-  End a build, deleting the current build context.
-
-* `acbuild annotation add NAME VALUE`
-
-  Updates the ACI to contain an annotation with the given name and value. If the
-  annotation already exists, its value will be changed.
-
-* `acbuild annotation remove NAME`
-
-  Removes the annotation with the given name from the ACI.
-
-* `acbuild dependency add IMAGE_NAME --image-id sha512-... --label env=canary`
-
-  Updates the ACI to contain a dependency with the given name. If the dependency
-  already exists, its values will be changed.
-
-* `acbuild dependency remove IMAGE_NAME`
-
-  Removes the dependency with the given image name from the ACI.
-
-* `acbuild environment add NAME VALUE`
-
-  Updates the ACI to contain an environment variable with the given name and
-  value. If the variable already exists, its value will be changed.
-
-* `acbuild environment remove NAME`
-
-  Removes the environment variable with the given name from the ACI.
-
-* `acbuild label add NAME VALUE`
-
-  Updates the ACI to contain a label with the given name and value. If the label
-  already exists, its value will be changed.
-
-* `acbuild label remove NAME`
-
-  Removes the label with the given name from the ACI.
-
-* `acbuild mount add NAME PATH`
-
-  Updates the ACI to contain a mount point with the given name and path. If the
-  mount point already exists, its path will be changed.
-
-* `acbuild mount remove NAME`
-
-  Removes the mount point with the given name from the ACI.
-
-* `acbuild port add NAME PROTOCOL PORT`
-
-  Updates the ACI to contain a port with the given name, protocol, and port. If
-  the port already exists, its values will be changed.
-
-* `acbuild port remove NAME`
-
-  Removes the port with the given name from the ACI.
-
-* `acbuild copy PATH_ON_HOST PATH_IN_ACI`
-
-  Copy a file or directory from the local filesystem into the ACI.
-
-* `acbuild run CMD [ARGS]`
-
-  Run a given command in the ACI.
-
-* `acbuild set-name ACI_NAME`
-
-  Changes the name of the ACI in its manifest.
-
-* `acbuild set-group GROUP`
-
-  Set the group the app will run as inside the container.
-
-* `acbuild set-user USER`
-  
-  Set the user the app will run as inside the container
-
-* `acbuild set-exec CMD [ARGS]`
-
-  Sets the exec command in the ACI's manifest.
-
-### Default labels when starting with an empty ACI
-
-When `acbuild begin` isn't passed any arguments a minimal container is created.
-The rootfs is empty, there isn't an exec statement, there's just a placeholder
-name for the image, and so on. There will, however, be two labels created: the
-"os" and "arch" labels. These labels are populated based on the system's
-operating system and architecture, but they can always be overridden or removed
-during the build with the `label add` and `label remove` commands.
-
-### acbuild run
-
-`acbuild run` builds the root filesystem with any dependencies the ACI has
-using overlayfs, and then executes the given command using systemd-nspawn. The
-current ACI being built is the upper level in the overlayfs, and thus modified
-files that came from the ACI's dependencies will be copied into the ACI. More
-information on this behavior is available
-[here](https://www.kernel.org/doc/Documentation/filesystems/overlayfs.txt).
-
-`acbuild run` requires overlayfs if the ACI being operated upon has
-dependencies.
-
-`acbuild run` also requires root.
-
-### Signing ACIs
-
-When finishing a build with `acbuild write`, if the `--sign` flag is provided
-acbuild will sign the resulting ACI by invoking the `gpg` command on the
-system. By default the `--armor` and `--yes` flags are passed to `gpg`, but if
-this is not sufficient any arguments given to `acbuild end` after the ACI to
-write are passed along to `gpg`.
-
-Some examples:
+For users with Vagrant 1.5.x or greater, there's a provided `Vagrantfile` that
+can quickly get you set up with a Linux VM that has both acbuild and rkt. The
+following steps will grab acbuild, set up the machine, and ssh into it.
 
 ```
-acbuild write --sign mynewapp.aci
+git clone https://github.com/appc/acbuild
+cd acbuild
+vagrant up
+vagrant ssh
 ```
 
-```
-acbuild write --sign mynewapp.aci -- --no-default-keyring --keyring ./rkt.gpg
-```
+## Documentation
 
-### Context-Free Mode
-
-Calling `begin` and `end` with acbuild to make a single change to an existing
-ACI can be cumbersome, so acbuild provides a context free mode. The
-`--modify=path/to/app.aci` flag can be used to specify an ACI to modify, and
-when provided the current build context will be ignored and the change will be
-applied to the given ACI instead.
-
-## Planned features
-
-### Squash
-
-`acbuild squash`: fetch all the dependencies for the given image and squash them
-together into the ACI without dependencies.
-
-### Image pushing with write
-
-When acbuild goes to write the ACI, meta discovery could be performed on the
-name that was set for the ACI to find an endpoint to push the image to, instead
-of saving the ACI on the local filesystem.
-
-### Alternate execution engine
-
-Support multiple execution engines, notably runc.
+Documentation about acbuild and many of its commands is available in the
+[`Documentation`
+directory](https://github.com/appc/acbuild/tree/master/Documentation) in this
+repository.
 
 ## Examples
 
-Use apt-get to install nginx.
-
-```
-acbuild begin
-acbuild dependency add quay.io/fermayo/ubuntu
-acbuild run -- apt-get update
-acbuild run -- apt-get -y install nginx
-acbuild set-exec /usr/sbin/nginx
-acbuild set-name example.com/ubuntu-nginx
-acbuild write ubuntu-nginx.aci
-acbuild end
-```
+Check out the [`examples`
+directory](https://github.com/appc/acbuild/tree/master/examples) for some common
+applications being packaged into ACIs with `acbuild`.
 
 ## Related work
 
@@ -258,5 +112,3 @@ acbuild end
   `patch-manifest` subcommands. `acbuild` may subsume such functionality,
   leaving `actool` as a validator only.
 - https://github.com/blablacar/cnt
-
-


### PR DESCRIPTION
README was tweaked and greatly shortened. Documentation directory was
added, which includes a getting started guide, a description of context
free mode, and a suggested template for acbuild scripts. Each subcommand
got its own markdown file detailing its features and quirks.

Fixes https://github.com/appc/acbuild/issues/97 https://github.com/appc/acbuild/issues/99 