### PR TITLE
begin: require first char to be / or . when starting from local file

### DIFF
--- a/Documentation/subcommands/begin.md
+++ b/Documentation/subcommands/begin.md
@@ -45,6 +45,11 @@ When an ACI is specified, it is used as the starting point for the build as
 opposed to an empty image. If the image is to be fetched via meta discovery
 over http (as opposed to https), the `--insecure` flag must be used.
 
+If the ACI to begin from is on the local filesystem, the path to it must start
+with `.`, `~`, or `/`. As an example, if the ACI is in the current directory,
+then instead of passing in `alpine-latest-linux-amd64.aci`, what would be
+passed in is `./alpine-latest-linux-amd64.aci`.
+
 ## Examples
 
 ```bash


### PR DESCRIPTION
So as to provide better error messages when a user attempts to start a
build from a local file and this file doesn't exist, the user must
provide a path to the file starting with `/` or `.`.

Additionally, begin now properly cleans up whatever context it started
to make if an error is returned.