### PR TITLE
copy: made -T the default behavior, put old default behind --to-dir

### DIFF
--- a/acbuild/copy.go
+++ b/acbuild/copy.go
@@ -19,18 +19,18 @@ import (
 )
 
 var (
-	explicitTarget bool
-	cmdCopy        = &cobra.Command{
-		Use:     "copy PATH_ON_HOST... PATH_IN_ACI",
+	toDir   bool
+	cmdCopy = &cobra.Command{
+		Use:     "copy PATH_ON_HOST PATH_IN_ACI",
 		Short:   "Copy a file or directory into an ACI",
-		Example: "acbuild copy stuff/* nginx.conf /etc/nginx/",
+		Example: "acbuild copy nginx.conf /etc/nginx/nginx.conf",
 		Run:     runWrapper(runCopy),
 	}
 )
 
 func init() {
 	cmdAcbuild.AddCommand(cmdCopy)
-	cmdCopy.Flags().BoolVarP(&explicitTarget, "explicit-target", "T", false, "copy a single file/directory to the specified path")
+	cmdCopy.Flags().BoolVar(&toDir, "to-dir", false, "copy multiple files/directories to the specified directory")
 }
 
 func runCopy(cmd *cobra.Command, args []string) (exit int) {
@@ -38,7 +38,7 @@ func runCopy(cmd *cobra.Command, args []string) (exit int) {
 		cmd.Usage()
 		return 1
 	}
-	if len(args) < 2 || (explicitTarget && len(args) != 2) {
+	if (!toDir && len(args) != 2) || (toDir && len(args) < 2) {
 		stderr("copy: incorrect number of arguments")
 		return 1
 	}
@@ -48,10 +48,10 @@ func runCopy(cmd *cobra.Command, args []string) (exit int) {
 	}
 
 	var err error
-	if explicitTarget {
-		err = newACBuild().CopyToTarget(args[0], args[1])
-	} else {
+	if toDir {
 		err = newACBuild().CopyToDir(args[:len(args)-1], args[len(args)-1])
+	} else {
+		err = newACBuild().CopyToTarget(args[0], args[1])
 	}
 
 	if err != nil {

--- a/tests/copy_test.go
+++ b/tests/copy_test.go
@@ -120,7 +120,7 @@ func TestCopyOneDir(t *testing.T) {
 
 	mustBuildFS(sourceDir, files)
 
-	_, _, _, err = runACBuild(workingDir, "--debug", "copy", "-T", sourceDir, dest)
+	_, _, _, err = runACBuild(workingDir, "--debug", "copy", sourceDir, dest)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -143,7 +143,7 @@ func TestCopyOneFile(t *testing.T) {
 	sourceFile.Close()
 	defer os.RemoveAll(sourceFile.Name())
 
-	_, _, _, err = runACBuild(workingDir, "copy", "-T", sourceFile.Name(), dest)
+	_, _, _, err = runACBuild(workingDir, "copy", sourceFile.Name(), dest)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -168,7 +168,7 @@ func TestCopyOneDirToExistingDir(t *testing.T) {
 
 	const expectedErrorMsg = "copy: mkdir .acbuild/currentaci/rootfs/test: file exists\n"
 
-	_, _, stderr, err := runACBuild(workingDir, "copy", "-T", sourceDir, dest)
+	_, _, stderr, err := runACBuild(workingDir, "copy", sourceDir, dest)
 	if err != nil && stderr != expectedErrorMsg {
 		t.Fatalf("was expecting an error, but not this one:\n%v", err)
 	}
@@ -207,7 +207,7 @@ func TestCopyManyDirs(t *testing.T) {
 	}
 
 	// golang--
-	_, _, _, err = runACBuild(workingDir, append([]string{"copy"}, append(froms, dest)...)...)
+	_, _, _, err = runACBuild(workingDir, append([]string{"copy", "--to-dir"}, append(froms, dest)...)...)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -242,7 +242,7 @@ func TestCopyDirsAndFiles(t *testing.T) {
 	}
 
 	// golang--
-	_, _, _, err = runACBuild(workingDir, append([]string{"copy"}, append(froms, dest)...)...)
+	_, _, _, err = runACBuild(workingDir, append([]string{"copy", "--to-dir"}, append(froms, dest)...)...)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}


### PR DESCRIPTION
To make the semantics a little less confusing, I restored the original
default behavior of copy to be the default, and put the new behavior
introduced recently behind the `--to-dir` flag.

```
acbuild copy nginx.conf /etc/nginx/nginx.conf
acbuild copy --to-dir foo bar/* foo/bar /tmp/baz
```