### PR TITLE
run: don't register run commands with machined

### DIFF
--- a/lib/run.go
+++ b/lib/run.go
@@ -120,7 +120,7 @@ func (a *ACBuild) Run(cmd []string, insecure bool) (err error) {
 
 		nspawnpath = a.OverlayTargetPath
 	}
-	nspawncmd := []string{"systemd-nspawn", "-q", "-D", nspawnpath}
+	nspawncmd := []string{"systemd-nspawn", "-q", "--register=no", "-D", nspawnpath}
 
 	if man.App != nil {
 		for _, evar := range man.App.Environment {


### PR DESCRIPTION
This is necessary to allow for multiple run commands (for separate
builds) to be executing at the same time.

Fixes https://github.com/appc/acbuild/issues/131.