### PR TITLE
begin: when given a directory, use as initial rootfs

### DIFF
--- a/Documentation/subcommands/begin.md
+++ b/Documentation/subcommands/begin.md
@@ -11,7 +11,7 @@ the current directory is changed back to the location where `acbuild begin` was
 run. If this is undesirable, the `--work-path` flag can be provided to specify
 the location to store and access the build context.
 
-## Starting state
+## Starting with an empty ACI
 
 The build will default to starting with an empty ACI. The rootfs will be empty,
 and the manifest will look something like the following:
@@ -38,17 +38,33 @@ The `arch` and `os` labels are filled in with the architecture and operating
 system of the machine acbuild is running on. If this is undesirable, the labels
 can be modified or removed with the `acbuild label` command.
 
+## Starting with a pre-existing ACI
+
 The begin command can also be passed an ACI, either on the file system or an
 image name to fetch via [meta
 discovery](https://github.com/appc/spec/blob/master/spec/discovery.md#meta-discovery).
 When an ACI is specified, it is used as the starting point for the build as
-opposed to an empty image. If the image is to be fetched via meta discovery
-over http (as opposed to https), the `--insecure` flag must be used.
+opposed to an empty image. The ACI's manifest and rootfs will both come from
+the specified image.  If the image is to be fetched via meta discovery over
+http (as opposed to https), the `--insecure` flag must be used.
 
-If the ACI to begin from is on the local filesystem, the path to it must start
-with `.`, `~`, or `/`. As an example, if the ACI is in the current directory,
-then instead of passing in `alpine-latest-linux-amd64.aci`, what would be
-passed in is `./alpine-latest-linux-amd64.aci`.
+As before, if the ACI to begin from is on the local filesystem the path to it
+must start with `.`, `~`, or `/`. As an example, if the ACI is in the current
+directory, then instead of passing in `alpine-latest-linux-amd64.aci`, what
+would be passed in is `./alpine-latest-linux-amd64.aci`.
+
+## Starting with a pre-existing rootfs
+
+If the user has a rootfs they wish to use in the ACI, perhaps produced by a
+tool like [buildroot](http://buildroot.org/), a directory can be passed to
+begin. The contents of the directory will be copied into the ACI, and the ACI
+will have a manifest identical to when the begin command is not passed a
+directory.
+
+When specifying something on the local filesystem to the begin command, the
+path to it _must_ start with `.`, `~`, or `/`. As an example, if the directory
+is in the current directory, then instead of passing in `buildroot/output`,
+what would be passed in is `./buildroot/output`.
 
 ## Examples
 
@@ -57,4 +73,5 @@ acbuild begin
 acbuild begin ./my-app.aci
 acbuild begin quay.io/coreos/alpine-sh
 acbuild --work-path /tmp/mybuild begin
+acbuild begin ~/projects/buildroot/output/target
 ```

--- a/tests/begin_test.go
+++ b/tests/begin_test.go
@@ -22,6 +22,7 @@ import (
 	"path"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/appc/spec/aci"
 )
@@ -82,4 +83,32 @@ func TestBeginLocalACI(t *testing.T) {
 
 	checkManifest(t, workingDir, detailedManifest())
 	checkEmptyRootfs(t, workingDir)
+}
+
+func TestBeginLocalDirectory(t *testing.T) {
+	sourceDir, err := ioutil.TempDir("", "acbuild-test-begin")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(sourceDir)
+
+	time1 := time.Now()
+	files := []*buildFileInfo{
+		mkBuildFileInfoFile("file01", time1),
+		mkBuildFileInfoDir("dir01", time1),
+		mkBuildFileInfoFile("dir01/file01", time1),
+	}
+
+	mustBuildFS(sourceDir, files)
+
+	workingDir := mustTempDir()
+	defer cleanUpTest(workingDir)
+
+	_, _, _, err = runACBuild(workingDir, "begin", sourceDir)
+	if err != nil {
+		t.Fatalf("%s\n", err.Error())
+	}
+
+	checkManifest(t, workingDir, emptyManifest())
+	testMatchingFSTree(t, workingDir, sourceDir, "/")
 }


### PR DESCRIPTION
To allow for users to specify an entire rootfs for their ACI, support
has been added to the begin command to allow for starting from a given
directory. This results in a non-empty rootfs, and an empty manifest.

Fixes https://github.com/appc/acbuild/issues/130, but with a different workflow than @ericchiang was expecting.