### PR TITLE
dependency: added shorthand for specifying version tag

### DIFF
--- a/Documentation/subcommands/dependency.md
+++ b/Documentation/subcommands/dependency.md
@@ -36,6 +36,30 @@ The `add` command also has the following optional flags:
 - `--size`: the size of the dependency being added, in bytes. When this ACI is
   run, the retrieved dependency must have this size.
 
+The dependency being added also has a shorthand for specifying a version label
+with a `:` on the dependency's name. For example, the following two lines will
+behave identically:
+
+```bash
+acbuild dependency add example.com/debian --label version=jessie
+acbuild dependency add example.com/debian:jessie
+```
+
+## Image Name
+
+The `IMAGE_NAME` argument is a string that can define both the name used in
+meta discovery and a handful of labels. The syntax looks like this:
+`name[:version][,label1=value][,label2=value]`
+
+Everything except the name is optional. Some examples of this:
+
+```
+example.com/reduce-worker
+example.com/reduce-worker:1.0.0
+example.com/reduce-worker:1.0.0,channel=alpha
+example.com/reduce-worker:1.0.0,channel=alpha,env=staging
+```
+
 ## Examples
 
 ```bash

--- a/lib/dependencies.go
+++ b/lib/dependencies.go
@@ -42,7 +42,7 @@ func removeDep(imageName types.ACIdentifier) func(*schema.ImageManifest) error {
 // AddDependency will add a dependency with the given name, id, labels, and size
 // to the untarred ACI stored at a.CurrentACIPath. If the dependency already
 // exists its fields will be updated to the new values.
-func (a *ACBuild) AddDependency(imageName, imageId string, labels types.Labels, size uint) (err error) {
+func (a *ACBuild) AddDependency(imageName types.ACIdentifier, imageId *types.Hash, labels types.Labels, size uint) (err error) {
 	if err = a.lock(); err != nil {
 		return err
 	}
@@ -52,26 +52,12 @@ func (a *ACBuild) AddDependency(imageName, imageId string, labels types.Labels, 
 		}
 	}()
 
-	acid, err := types.NewACIdentifier(imageName)
-	if err != nil {
-		return err
-	}
-
-	var hash *types.Hash
-	if imageId != "" {
-		var err error
-		hash, err = types.NewHash(imageId)
-		if err != nil {
-			return err
-		}
-	}
-
 	fn := func(s *schema.ImageManifest) error {
-		removeDep(*acid)(s)
+		removeDep(imageName)(s)
 		s.Dependencies = append(s.Dependencies,
 			types.Dependency{
-				ImageName: *acid,
-				ImageID:   hash,
+				ImageName: imageName,
+				ImageID:   imageId,
 				Labels:    labels,
 				Size:      size,
 			})


### PR DESCRIPTION
Adds : syntax for specifying dependency versions. The two lines now do
the same thing:

```
acbuild dep add example.com/debian:jessie
acbuild dep add example.com/debian --label version=jessie
```

Partially fixes https://github.com/appc/acbuild/issues/128.