### PR TITLE
run: don't pass -q flag to systemd-nspawn for systemd < 209

### DIFF
--- a/lib/run.go
+++ b/lib/run.go
@@ -120,7 +120,15 @@ func (a *ACBuild) Run(cmd []string, insecure bool) (err error) {
 
 		nspawnpath = a.OverlayTargetPath
 	}
-	nspawncmd := []string{"systemd-nspawn", "-q", "--register=no", "-D", nspawnpath}
+	nspawncmd := []string{"systemd-nspawn", "-D", nspawnpath}
+
+	version, err := getSystemdVersion()
+	if err != nil {
+		return err
+	}
+	if version >= 209 {
+		nspawncmd = append(nspawncmd, "--quiet", "--register=no")
+	}
 
 	if man.App != nil {
 		for _, evar := range man.App.Environment {
@@ -295,4 +303,27 @@ func (a *ACBuild) mirrorLocalZoneInfo() error {
 	}
 
 	return nil
+}
+
+func getSystemdVersion() (int, error) {
+	_, err := exec.LookPath("systemctl")
+	if err == exec.ErrNotFound {
+		return 0, fmt.Errorf("system does not have systemd")
+	}
+
+	blob, err := exec.Command("systemctl", "--version").Output()
+	if err != nil {
+		return 0, err
+	}
+	for _, line := range strings.Split(string(blob), "\n") {
+		if strings.HasPrefix(line, "systemd ") {
+			var version int
+			_, err := fmt.Sscanf(line, "systemd %d", &version)
+			if err != nil {
+				return 0, err
+			}
+			return version, nil
+		}
+	}
+	return 0, fmt.Errorf("error parsing output from `systemctl --version`")
 }


### PR DESCRIPTION
The -q/--quiet flag was added to systemd-nspawn in version 209, and some
distros (like CentOS 7) ship with an older version than that. This
commit runs and parses `systemctl --version` to determine the version
number of systemd, and will only pass the --quiet flag if it's high
enough.

Fixes https://github.com/appc/acbuild/issues/140