### PR TITLE
*: add annotations to track acbuild commands

### DIFF
--- a/Documentation/command-history.md
+++ b/Documentation/command-history.md
@@ -1,0 +1,44 @@
+# Command History
+
+By default, acbuild will maintain annotations in the ACI it's modifying to
+track the acbuild commands that were performed on that ACI. The name of the
+annotation follows the pattern `appc.io/acbuild/command-X` where X is a number,
+and the value of the annotation will be the acbuild command that was called.
+
+For example, the following acbuild commands:
+
+```bash
+acbuild begin
+acbuild set-name example.com/nginx
+acbuild dep add quay.io/coreos/alpine-sh
+acbuild run -- apk update
+acbuild run -- apk add nginx
+acbuild write nginx.aci
+acbuild end
+```
+
+result in the manifest in `nginx.aci` containing the following annotations:
+
+```json
+[
+    {
+        "name": "appc.io/acbuild/command-1",
+        "value": "acbuild set-name \"example.com/nginx\""
+    },
+    {
+        "name": "appc.io/acbuild/command-2",
+        "value": "acbuild dependency add \"quay.io/coreos/alpine-sh\""
+    },
+    {
+        "name": "appc.io/acbuild/command-3",
+        "value": "acbuild run \"apk\" \"update\""
+    },
+    {
+        "name": "appc.io/acbuild/command-4",
+        "value": "acbuild run \"apk\" \"add\" \"nginx\""
+    }
+]
+```
+
+This command tracking can easily be turned off, by providing the `--no-history`
+flag to any command that should not generate this additional annotation.

--- a/tests/annotation_test.go
+++ b/tests/annotation_test.go
@@ -43,7 +43,7 @@ func TestAddAnnotation(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "annotation", "add", annoName, annoValue)
+	err := runACBuildNoHist(workingDir, "annotation", "add", annoName, annoValue)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -56,12 +56,12 @@ func TestAddRmAnnotation(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "annotation", "add", annoName, annoValue)
+	err := runACBuildNoHist(workingDir, "annotation", "add", annoName, annoValue)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "annotation", "remove", annoName)
+	err = runACBuildNoHist(workingDir, "annotation", "remove", annoName)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -74,12 +74,12 @@ func TestAddOverwriteAnnotation(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "annotation", "add", annoName, annoValue)
+	err := runACBuildNoHist(workingDir, "annotation", "add", annoName, annoValue)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "annotation", "add", annoName, annoValue)
+	err = runACBuildNoHist(workingDir, "annotation", "add", annoName, annoValue)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -92,7 +92,7 @@ func TestRmNonexistentAnnotation(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	exitCode, _, _, err := runACBuild(workingDir, "annotation", "remove", annoName)
+	exitCode, _, _, err := runACBuild(workingDir, "--no-history", "annotation", "remove", annoName)
 	switch {
 	case err == nil:
 		t.Fatalf("annotation remove didn't return an error when asked to remove nonexistent annotation")
@@ -112,17 +112,17 @@ func TestAddAddRmAnnotation(t *testing.T) {
 
 	const suffix = "1"
 
-	_, _, _, err := runACBuild(workingDir, "annotation", "add", annoName+suffix, annoValue)
+	err := runACBuildNoHist(workingDir, "annotation", "add", annoName+suffix, annoValue)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "annotation", "add", annoName, annoValue)
+	err = runACBuildNoHist(workingDir, "annotation", "add", annoName, annoValue)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "annotation", "remove", annoName+suffix)
+	err = runACBuildNoHist(workingDir, "annotation", "remove", annoName+suffix)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}

--- a/tests/common.go
+++ b/tests/common.go
@@ -126,6 +126,11 @@ func detailedManifest() schema.ImageManifest {
 	}
 }
 
+func runACBuildNoHist(workingDir string, args ...string) error {
+	_, _, _, err := runACBuild(workingDir, append([]string{"--no-history"}, args...)...)
+	return err
+}
+
 // runACBuild takes the workingDir and args to call ACBuild with, calls
 // acbuild, and returns it's exit code, what it printed to stdout, what it
 // printed to stderr, and an error in the event of a non-0 exit code.

--- a/tests/copy_test.go
+++ b/tests/copy_test.go
@@ -120,7 +120,7 @@ func TestCopyOneDir(t *testing.T) {
 
 	mustBuildFS(sourceDir, files)
 
-	_, _, _, err = runACBuild(workingDir, "--debug", "copy", sourceDir, dest)
+	err = runACBuildNoHist(workingDir, "--debug", "copy", sourceDir, dest)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -143,7 +143,7 @@ func TestCopyOneFile(t *testing.T) {
 	sourceFile.Close()
 	defer os.RemoveAll(sourceFile.Name())
 
-	_, _, _, err = runACBuild(workingDir, "copy", sourceFile.Name(), dest)
+	err = runACBuildNoHist(workingDir, "copy", sourceFile.Name(), dest)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -168,7 +168,7 @@ func TestCopyOneDirToExistingDir(t *testing.T) {
 
 	const expectedErrorMsg = "copy: mkdir .acbuild/currentaci/rootfs/test: file exists\n"
 
-	_, _, stderr, err := runACBuild(workingDir, "copy", sourceDir, dest)
+	_, _, stderr, err := runACBuild(workingDir, "--no-history", "copy", sourceDir, dest)
 	if err != nil && stderr != expectedErrorMsg {
 		t.Fatalf("was expecting an error, but not this one:\n%v", err)
 	}
@@ -207,7 +207,7 @@ func TestCopyManyDirs(t *testing.T) {
 	}
 
 	// golang--
-	_, _, _, err = runACBuild(workingDir, append([]string{"copy", "--to-dir"}, append(froms, dest)...)...)
+	err = runACBuildNoHist(workingDir, append([]string{"copy", "--to-dir"}, append(froms, dest)...)...)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -242,7 +242,7 @@ func TestCopyDirsAndFiles(t *testing.T) {
 	}
 
 	// golang--
-	_, _, _, err = runACBuild(workingDir, append([]string{"copy", "--to-dir"}, append(froms, dest)...)...)
+	err = runACBuildNoHist(workingDir, append([]string{"copy", "--to-dir"}, append(froms, dest)...)...)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}

--- a/tests/dependency_test.go
+++ b/tests/dependency_test.go
@@ -48,7 +48,7 @@ func TestAddDependency(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "dependency", "add", depName)
+	err := runACBuildNoHist(workingDir, "dependency", "add", depName)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -67,7 +67,7 @@ func TestAddDependencyWithImageID(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "dependency", "add", depName, "--image-id", depImageID)
+	err := runACBuildNoHist(workingDir, "dependency", "add", depName, "--image-id", depImageID)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -92,7 +92,7 @@ func TestAddDependencyWithLabels(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "dependency", "add", depName,
+	err := runACBuildNoHist(workingDir, "dependency", "add", depName,
 		"--label", newLabel(depLabel1Key, depLabel1Val),
 		"--label", newLabel(depLabel2Key, depLabel2Val))
 	if err != nil {
@@ -123,7 +123,7 @@ func TestAddDependencyWithSize(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "dependency", "add", depName, "--size", strconv.Itoa(int(depSize)))
+	err := runACBuildNoHist(workingDir, "dependency", "add", depName, "--size", strconv.Itoa(int(depSize)))
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -143,7 +143,7 @@ func TestAdd2Dependencies(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "dependency", "add", depName,
+	err := runACBuildNoHist(workingDir, "dependency", "add", depName,
 		"--image-id", depImageID,
 		"--label", newLabel(depLabel1Key, depLabel1Val),
 		"--label", newLabel(depLabel2Key, depLabel2Val),
@@ -152,7 +152,7 @@ func TestAdd2Dependencies(t *testing.T) {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "dependency", "add", depName2)
+	err = runACBuildNoHist(workingDir, "dependency", "add", depName2)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -191,7 +191,7 @@ func TestAddAddRmDependencies(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "dependency", "add", depName,
+	err := runACBuildNoHist(workingDir, "dependency", "add", depName,
 		"--image-id", depImageID,
 		"--label", newLabel(depLabel1Key, depLabel1Val),
 		"--label", newLabel(depLabel2Key, depLabel2Val),
@@ -200,12 +200,12 @@ func TestAddAddRmDependencies(t *testing.T) {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "dependency", "add", depName2)
+	err = runACBuildNoHist(workingDir, "dependency", "add", depName2)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "dependency", "remove", depName)
+	err = runACBuildNoHist(workingDir, "dependency", "remove", depName)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -224,7 +224,7 @@ func TestAddRmDependencie(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "dependency", "add", depName,
+	err := runACBuildNoHist(workingDir, "dependency", "add", depName,
 		"--image-id", depImageID,
 		"--label", newLabel(depLabel1Key, depLabel1Val),
 		"--label", newLabel(depLabel2Key, depLabel2Val),
@@ -233,7 +233,7 @@ func TestAddRmDependencie(t *testing.T) {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "dependency", "remove", depName)
+	err = runACBuildNoHist(workingDir, "dependency", "remove", depName)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -246,7 +246,7 @@ func TestOverwriteDependency(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "dependency", "add", depName,
+	err := runACBuildNoHist(workingDir, "dependency", "add", depName,
 		"--image-id", depImageID,
 		"--label", newLabel(depLabel1Key, depLabel1Val),
 		"--label", newLabel(depLabel2Key, depLabel2Val),
@@ -255,7 +255,7 @@ func TestOverwriteDependency(t *testing.T) {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "dependency", "add", depName)
+	err = runACBuildNoHist(workingDir, "dependency", "add", depName)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -274,7 +274,7 @@ func TestRmNonexistentDependency(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	exitCode, _, _, err := runACBuild(workingDir, "dependency", "remove", depName)
+	exitCode, _, _, err := runACBuild(workingDir, "--no-history", "dependency", "remove", depName)
 	switch {
 	case err == nil:
 		t.Fatalf("dependency remove didn't return an error when asked to remove nonexistent dependency")

--- a/tests/environment_test.go
+++ b/tests/environment_test.go
@@ -39,7 +39,7 @@ func TestAddEnv(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "environment", "add", envName, envVal)
+	err := runACBuildNoHist(workingDir, "environment", "add", envName, envVal)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -59,12 +59,12 @@ func TestAddTwoEnv(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "environment", "add", envName, envVal)
+	err := runACBuildNoHist(workingDir, "environment", "add", envName, envVal)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "environment", "add", envName2, envVal2)
+	err = runACBuildNoHist(workingDir, "environment", "add", envName2, envVal2)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -88,17 +88,17 @@ func TestAddAddRmEnv(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "environment", "add", envName, envVal)
+	err := runACBuildNoHist(workingDir, "environment", "add", envName, envVal)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "environment", "add", envName2, envVal2)
+	err = runACBuildNoHist(workingDir, "environment", "add", envName2, envVal2)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "environment", "rm", envName)
+	err = runACBuildNoHist(workingDir, "environment", "rm", envName)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -118,12 +118,12 @@ func TestAddOverwriteEnv(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "environment", "add", envName, envVal)
+	err := runACBuildNoHist(workingDir, "environment", "add", envName, envVal)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "environment", "add", envName, envVal2)
+	err = runACBuildNoHist(workingDir, "environment", "add", envName, envVal2)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -143,12 +143,12 @@ func TestAddRmEnv(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "environment", "add", envName, envVal)
+	err := runACBuildNoHist(workingDir, "environment", "add", envName, envVal)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "environment", "rm", envName)
+	err = runACBuildNoHist(workingDir, "environment", "rm", envName)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -161,7 +161,7 @@ func TestRmNonexistentEnv(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	exitCode, _, _, err := runACBuild(workingDir, "environment", "rm", envName)
+	exitCode, _, _, err := runACBuild(workingDir, "--no-history", "environment", "rm", envName)
 	switch {
 	case err == nil:
 		t.Fatalf("environment remove didn't return an error when asked to remove nonexistent environment variable")

--- a/tests/label_test.go
+++ b/tests/label_test.go
@@ -39,7 +39,7 @@ func TestAddLabel(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "label", "add", labelName, labelVal)
+	err := runACBuildNoHist(workingDir, "label", "add", labelName, labelVal)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -59,12 +59,12 @@ func TestAddTwoLabels(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "label", "add", labelName, labelVal)
+	err := runACBuildNoHist(workingDir, "label", "add", labelName, labelVal)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "label", "add", labelName2, labelVal2)
+	err = runACBuildNoHist(workingDir, "label", "add", labelName2, labelVal2)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -88,17 +88,17 @@ func TestAddAddRmLabels(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "label", "add", labelName, labelVal)
+	err := runACBuildNoHist(workingDir, "label", "add", labelName, labelVal)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "label", "add", labelName2, labelVal2)
+	err = runACBuildNoHist(workingDir, "label", "add", labelName2, labelVal2)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "label", "rm", labelName)
+	err = runACBuildNoHist(workingDir, "label", "rm", labelName)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -118,12 +118,12 @@ func TestAddOverwriteLabel(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "label", "add", labelName, labelVal)
+	err := runACBuildNoHist(workingDir, "label", "add", labelName, labelVal)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "label", "add", labelName, labelVal2)
+	err = runACBuildNoHist(workingDir, "label", "add", labelName, labelVal2)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -143,12 +143,12 @@ func TestAddRmLabel(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "label", "add", labelName, labelVal)
+	err := runACBuildNoHist(workingDir, "label", "add", labelName, labelVal)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "label", "rm", labelName)
+	err = runACBuildNoHist(workingDir, "label", "rm", labelName)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -161,7 +161,7 @@ func TestRmNonexistentLabel(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	exitCode, _, _, err := runACBuild(workingDir, "label", "rm", labelName)
+	exitCode, _, _, err := runACBuild(workingDir, "--no-history", "label", "rm", labelName)
 	switch {
 	case err == nil:
 		t.Fatalf("label remove didn't return an error when asked to remove nonexistent label")

--- a/tests/mount_test.go
+++ b/tests/mount_test.go
@@ -39,7 +39,7 @@ func TestAddMount(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "mount", "add", mountName, mountPath)
+	err := runACBuildNoHist(workingDir, "mount", "add", mountName, mountPath)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -59,7 +59,7 @@ func TestAddMountReadOnly(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "mount", "add", mountName, mountPath, "--read-only")
+	err := runACBuildNoHist(workingDir, "mount", "add", mountName, mountPath, "--read-only")
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -80,12 +80,12 @@ func TestAdd2Mounts(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "mount", "add", mountName, mountPath, "--read-only")
+	err := runACBuildNoHist(workingDir, "mount", "add", mountName, mountPath, "--read-only")
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "mount", "add", mountName2, mountPath2)
+	err = runACBuildNoHist(workingDir, "mount", "add", mountName2, mountPath2)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -110,17 +110,17 @@ func TestAddAddRmMounts(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "mount", "add", mountName, mountPath, "--read-only")
+	err := runACBuildNoHist(workingDir, "mount", "add", mountName, mountPath, "--read-only")
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "mount", "add", mountName2, mountPath2)
+	err = runACBuildNoHist(workingDir, "mount", "add", mountName2, mountPath2)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "mount", "rm", mountName)
+	err = runACBuildNoHist(workingDir, "mount", "rm", mountName)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -140,12 +140,12 @@ func TestAddRmMount(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "mount", "add", mountName, mountPath, "--read-only")
+	err := runACBuildNoHist(workingDir, "mount", "add", mountName, mountPath, "--read-only")
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "mount", "rm", mountName)
+	err = runACBuildNoHist(workingDir, "mount", "rm", mountName)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -158,12 +158,12 @@ func TestOverwriteMount(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "mount", "add", mountName, mountPath, "--read-only")
+	err := runACBuildNoHist(workingDir, "mount", "add", mountName, mountPath, "--read-only")
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "mount", "add", mountName, mountPath2)
+	err = runACBuildNoHist(workingDir, "mount", "add", mountName, mountPath2)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -183,7 +183,7 @@ func TestRmNonexistentMount(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	exitCode, _, _, err := runACBuild(workingDir, "mount", "rm", mountName)
+	exitCode, _, _, err := runACBuild(workingDir, "--no-history", "mount", "rm", mountName)
 	switch {
 	case err == nil:
 		t.Fatalf("mount remove didn't return an error when asked to remove nonexistent mount")

--- a/tests/port_test.go
+++ b/tests/port_test.go
@@ -43,7 +43,7 @@ func TestAddPort(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "port", "add", portName, portProtocol, strconv.Itoa(int(portNumber)))
+	err := runACBuildNoHist(workingDir, "port", "add", portName, portProtocol, strconv.Itoa(int(portNumber)))
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -65,7 +65,7 @@ func TestAddPortWithCount(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "port", "add", portName, portProtocol, strconv.Itoa(int(portNumber)),
+	err := runACBuildNoHist(workingDir, "port", "add", portName, portProtocol, strconv.Itoa(int(portNumber)),
 		"--count", strconv.Itoa(int(portCount)))
 	if err != nil {
 		t.Fatalf("%v\n", err)
@@ -88,7 +88,7 @@ func TestAddPortWithSocketActivated(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "port", "add", portName, portProtocol, strconv.Itoa(int(portNumber)),
+	err := runACBuildNoHist(workingDir, "port", "add", portName, portProtocol, strconv.Itoa(int(portNumber)),
 		"--socket-activated")
 	if err != nil {
 		t.Fatalf("%v\n", err)
@@ -113,7 +113,7 @@ func TestAddNegativePort(t *testing.T) {
 	defer cleanUpTest(workingDir)
 
 	// The "--" is required to prevent cobra from parsing the "-1" as a flag
-	_, _, _, err := runACBuild(workingDir, "port", "add", portName, portProtocol, "--", "-1")
+	err := runACBuildNoHist(workingDir, "port", "add", portName, portProtocol, "--", "-1")
 	if err == nil {
 		t.Fatalf("port add didn't return an error when asked to add a port with a negative number")
 	}
@@ -126,7 +126,7 @@ func TestAddPortThatsTooHigh(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "port", "add", portName, portProtocol, "65536")
+	err := runACBuildNoHist(workingDir, "port", "add", portName, portProtocol, "65536")
 	if err == nil {
 		t.Fatalf("port add didn't return an error when asked to add a port with a number > 65535")
 	}
@@ -139,12 +139,12 @@ func TestAddTwoPorts(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "port", "add", portName, portProtocol, strconv.Itoa(int(portNumber)))
+	err := runACBuildNoHist(workingDir, "port", "add", portName, portProtocol, strconv.Itoa(int(portNumber)))
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "port", "add", portName2, portProtocol2, strconv.Itoa(int(portNumber2)))
+	err = runACBuildNoHist(workingDir, "port", "add", portName2, portProtocol2, strconv.Itoa(int(portNumber2)))
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -172,12 +172,12 @@ func TestAddRmPorts(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "port", "add", portName, portProtocol, strconv.Itoa(int(portNumber)))
+	err := runACBuildNoHist(workingDir, "port", "add", portName, portProtocol, strconv.Itoa(int(portNumber)))
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "port", "rm", portName)
+	err = runACBuildNoHist(workingDir, "port", "rm", portName)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -190,17 +190,17 @@ func TestAddAddRmPorts(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	_, _, _, err := runACBuild(workingDir, "port", "add", portName, portProtocol, strconv.Itoa(int(portNumber)))
+	err := runACBuildNoHist(workingDir, "port", "add", portName, portProtocol, strconv.Itoa(int(portNumber)))
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "port", "add", portName2, portProtocol2, strconv.Itoa(int(portNumber2)))
+	err = runACBuildNoHist(workingDir, "port", "add", portName2, portProtocol2, strconv.Itoa(int(portNumber2)))
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
 
-	_, _, _, err = runACBuild(workingDir, "port", "rm", portName)
+	err = runACBuildNoHist(workingDir, "port", "rm", portName)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -222,7 +222,7 @@ func TestRmNonexistentPorts(t *testing.T) {
 	workingDir := setUpTest(t)
 	defer cleanUpTest(workingDir)
 
-	exitCode, _, _, err := runACBuild(workingDir, "port", "remove", portName)
+	exitCode, _, _, err := runACBuild(workingDir, "--no-history", "port", "remove", portName)
 	switch {
 	case err == nil:
 		t.Fatalf("port remove didn't return an error when asked to remove nonexistent port")

--- a/tests/replace-manifest_test.go
+++ b/tests/replace-manifest_test.go
@@ -54,7 +54,7 @@ func testReplaceWithManifest(t *testing.T, workingDir string, manblob []byte) {
 	}
 	file.Close()
 
-	_, _, _, err = runACBuild(workingDir, "replace-manifest", file.Name())
+	err = runACBuildNoHist(workingDir, "replace-manifest", file.Name())
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/tests/set-event-handler_test.go
+++ b/tests/set-event-handler_test.go
@@ -33,7 +33,7 @@ func TestEHPreStart(t *testing.T) {
 
 	var prestart = []string{"/bin/sh", "-c", "'chmod 755 /'"}
 
-	_, _, _, err := runACBuild(workingDir, append([]string{"set-event-handler", "pre-start", "--"}, prestart...)...)
+	err := runACBuildNoHist(workingDir, append([]string{"set-event-handler", "pre-start", "--"}, prestart...)...)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -53,7 +53,7 @@ func TestEHPostStop(t *testing.T) {
 
 	var poststop = []string{"/bin/rm", "-rf", "/Plex Media Server/plexmediaserver.pid"}
 
-	_, _, _, err := runACBuild(workingDir, append([]string{"set-event-handler", "post-stop", "--"}, poststop...)...)
+	err := runACBuildNoHist(workingDir, append([]string{"set-event-handler", "post-stop", "--"}, poststop...)...)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}

--- a/tests/set-exec_test.go
+++ b/tests/set-exec_test.go
@@ -24,7 +24,7 @@ func TestSetExec(t *testing.T) {
 
 	var exec = []string{"/bin/nethack4", "-D", "wizard"}
 
-	_, _, _, err := runACBuild(workingDir, append([]string{"set-exec", "--"}, exec...)...)
+	err := runACBuildNoHist(workingDir, append([]string{"set-exec", "--"}, exec...)...)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}

--- a/tests/set-group_test.go
+++ b/tests/set-group_test.go
@@ -24,7 +24,7 @@ func TestSetGroup(t *testing.T) {
 
 	const group = "10"
 
-	_, _, _, err := runACBuild(workingDir, "set-group", group)
+	err := runACBuildNoHist(workingDir, "set-group", group)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}

--- a/tests/set-name_test.go
+++ b/tests/set-name_test.go
@@ -26,7 +26,7 @@ func TestSetName(t *testing.T) {
 
 	const name = "example.com/app"
 
-	_, _, _, err := runACBuild(workingDir, "set-name", name)
+	err := runACBuildNoHist(workingDir, "set-name", name)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}

--- a/tests/set-user_test.go
+++ b/tests/set-user_test.go
@@ -24,7 +24,7 @@ func TestSetUser(t *testing.T) {
 
 	const user = "10"
 
-	_, _, _, err := runACBuild(workingDir, "set-user", user)
+	err := runACBuildNoHist(workingDir, "set-user", user)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}

--- a/tests/set-working-directory_test.go
+++ b/tests/set-working-directory_test.go
@@ -24,7 +24,7 @@ func TestSetWorkingDir(t *testing.T) {
 
 	const wd = "/root"
 
-	_, _, _, err := runACBuild(workingDir, "set-working-dir", wd)
+	err := runACBuildNoHist(workingDir, "set-working-dir", wd)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}


### PR DESCRIPTION
This commit has acbuild maintain annotations following
"acbuild-command-%d". Each new acbuild command that isn't something like
cat-manifest or write results in a new annotation being added to the
image, containing the command that was run.

Fixes https://github.com/appc/acbuild/issues/120.