### PR TITLE
Fully resolves the path to /etc/localtime on the host.

### DIFF
--- a/lib/run.go
+++ b/lib/run.go
@@ -266,7 +266,7 @@ func genDeplist(acipath string, reg registry.Registry) ([]string, error) {
 }
 
 func (a *ACBuild) mirrorLocalZoneInfo() error {
-	zif, err := os.Readlink("/etc/localtime")
+	zif, err := filepath.EvalSymlinks("/etc/localtime")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #145.  Also affects #142: `usr` is no longer a child of `rootfs` and `manifest` in `.acbuild/currentaci`.