### PR TITLE
run: set the PATH variable if not set by manifest

### DIFF
--- a/lib/run.go
+++ b/lib/run.go
@@ -135,6 +135,7 @@ func (a *ACBuild) Run(cmd []string, insecure bool) (err error) {
 			nspawncmd = append(nspawncmd, "--setenv", evar.Name+"="+evar.Value)
 		}
 	}
+	nspawncmd = append(nspawncmd, "--setenv", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
 
 	err = a.mirrorLocalZoneInfo()
 	if err != nil {


### PR DESCRIPTION
Depending on the image, the PATH variable inside of a acbuild run
command could be propagated from something on the host. On normal
distros, this was mostly a non-issue. On NixOS, it would get set to
"/no-such-path:/sbin:/bin", which is definitely an issue.

This commit checks if the PATH environment variable has been set in the
ACI's manifest (which gets added to the systemd-nspawn command), and if
it has not it sets it to
"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".

Note that it only sets it on the systemd-nspawn command, it doesn't
add or modify the PATH variable in the manifest.