### PR TITLE
run: show a friendlier error message when unable to modprobe overlayfs

### DIFF
--- a/lib/run.go
+++ b/lib/run.go
@@ -82,6 +82,9 @@ func (a *ACBuild) Run(cmd []string, insecure bool) (err error) {
 		if !supportsOverlay() {
 			err := exec.Command("modprobe", "overlay").Run()
 			if err != nil {
+				if _, ok := err.(*exec.ExitError); ok {
+					return fmt.Errorf("overlayfs is not supported on your system")
+				}
 				return err
 			}
 			if !supportsOverlay() {


### PR DESCRIPTION
If overlayfs isn't available on a user's system, acbuild attempts to modprobe it. If this fails, acbuild would exit with `run: exit status 1`. This is a very confusing error message to receive, so this commit checks for this failure and instead prints `run: overlayfs is not supported on your system`.

Fixes https://github.com/appc/acbuild/issues/164