### PR TITLE
run: check that the binary exists, error if not

### DIFF
--- a/lib/run.go
+++ b/lib/run.go
@@ -149,6 +149,15 @@ func (a *ACBuild) Run(cmd []string, insecure bool) (err error) {
 	if err != nil {
 		return err
 	}
+
+	_, err = os.Lstat(path.Join(nspawnpath, abscmd))
+	switch {
+	case os.IsNotExist(err):
+		return fmt.Errorf("the binary %q doesn't exist", abscmd)
+	case err != nil:
+		return err
+	}
+
 	nspawncmd = append(nspawncmd, abscmd)
 	nspawncmd = append(nspawncmd, cmd[1:]...)
 


### PR DESCRIPTION
acbuild run will now check if the given binary exists, and will print a
nice error message if it doesn't, as opposed to relying on
systemd-nspawn to inform the user.

Fixes https://github.com/appc/acbuild/issues/165.

New behavior:
```
[nix-shell:~/go/src/github.com/appc/acbuild]$ sudo ./bin/acbuild run /bin/sh
/bin/sh: can't access tty; job control turned off
/ # 
[nix-shell:~/go/src/github.com/appc/acbuild]$ sudo ./bin/acbuild run /bin/shz
run: the binary "/bin/shz" doesn't exist

[nix-shell:~/go/src/github.com/appc/acbuild]$ sudo ./bin/acbuild run shz
run: shz not found in any of: [/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin]

[nix-shell:~/go/src/github.com/appc/acbuild]$ sudo ./bin/acbuild run sh
/bin/sh: can't access tty; job control turned off
/ # 
```