### PR TITLE
copy: split --to-dir flag into separate subcommand

### DIFF
--- a/Documentation/subcommands/copy-to-dir.md
+++ b/Documentation/subcommands/copy-to-dir.md
@@ -1,0 +1,22 @@
+# acbuild copy-to-dir
+
+`acbuild copy-to-dir` will copy any number of files and directories from the
+local filesystem into the ACI.
+
+It takes at least two arguments, where all but the final argument are paths on
+the host system. The final argument is a parent directory inside the ACI to
+place the files and directories in.
+
+If the target directory doesn't exist in the ACI, it will be implicitly created
+(along with any necessary parent directories).
+
+The following commands would do the same thing:
+
+```bash
+acbuild copy-to-dir apache.conf sites-available/00-default sites-available/myblog /etc/apache2
+```
+
+```bash
+cp apache.conf sites-available/00-default sites-available/myblog ./.acbuild/currentaci/rootfs/etc/apache2
+```
+

--- a/Documentation/subcommands/copy.md
+++ b/Documentation/subcommands/copy.md
@@ -1,16 +1,9 @@
 # acbuild copy
 
-`acbuild copy` will copy files and directories from the local filesystem into
+`acbuild copy` will copy one file or directory from the local filesystem into
 the ACI.
 
-There are two modes of operation for `acbuild copy`, one for copying multiple
-files/directories into a specified directory, and one for copying a single
-file/directory to a specified path.
-
-## Default Mode
-
-By default, `acbuild copy` will copy one thing from the host to a specified
-path. It takes exactly two arguments, the first of which is the path on the
+It takes exactly two arguments, the first of which is the path on the
 local system to copy from, and the second is the path inside the ACI to copy
 to. If the target path's parent directory does not exist in the filesystem, it
 will be implicitly created (along with any necessary parent directories).
@@ -24,22 +17,3 @@ acbuild copy ./nginx.conf /etc/nginx/nginx.conf
 ```bash
 cp ./nginx.conf ./.acbuild/currentaci/rootfs/etc/nginx/nginx.conf
 ```
-
-## Explicit Target Mode
-
-When the `--to-dir` flag is used, `acbuild copy` takes any number of arguments
-greater than or equal to 2. The last specified argument is the directory inside
-the ACI to put the files in, and all other arguments are paths on the host to
-copy. If the target directory doesn't exist in the ACI, it will be implicitly
-created (along with any necessary parent directories).
-
-The following commands would do the same thing:
-
-```bash
-acbuild copy --to-dir apache.conf sites-available/00-default sites-available/myblog /etc/apache2
-```
-
-```bash
-cp apache.conf sites-available/00-default sites-available/myblog /etc/apache2
-```
-

--- a/acbuild/copy-to-dir.go
+++ b/acbuild/copy-to-dir.go
@@ -15,40 +15,49 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/appc/acbuild/Godeps/_workspace/src/github.com/spf13/cobra"
 )
 
 var (
-	cmdCopy = &cobra.Command{
-		Use:     "copy PATH_ON_HOST PATH_IN_ACI",
-		Short:   "Copy a file or directory into an ACI",
-		Example: "acbuild copy nginx.conf /etc/nginx/nginx.conf",
-		Run:     runWrapper(runCopy),
+	toDir        bool
+	cmdCopyToDir = &cobra.Command{
+		Use:     "copy-to-dir PATH1_ON_HOST PATH2_ON_HOST ... PATH_IN_ACI",
+		Short:   "Copy a file or directory into a directory in an ACI",
+		Example: "acbuild copy-to-dir build/bin/* /usr/bin",
+		Run:     runWrapper(runCopyToDir),
 	}
 )
 
 func init() {
-	cmdAcbuild.AddCommand(cmdCopy)
+	cmdAcbuild.AddCommand(cmdCopyToDir)
 }
 
-func runCopy(cmd *cobra.Command, args []string) (exit int) {
+func runCopyToDir(cmd *cobra.Command, args []string) (exit int) {
 	if len(args) == 0 {
 		cmd.Usage()
 		return 1
 	}
-	if len(args) != 2 {
-		stderr("copy: incorrect number of arguments")
+	if len(args) < 2 {
+		stderr("copy-to-dir: incorrect number of arguments")
 		return 1
 	}
 
 	if debug {
-		stderr("Copying host:%s to aci:%s", args[0], args[1])
+		logMsg := "Copying "
+		for i := 0; i < len(args)-1; i++ {
+			logMsg += fmt.Sprintf("%s ", args[i])
+		}
+		logMsg += "to "
+		logMsg += fmt.Sprintf("%s", args[len(args)-1])
+		stderr(logMsg)
 	}
 
-	err := newACBuild().CopyToTarget(args[0], args[1])
+	err := newACBuild().CopyToDir(args[:len(args)-1], args[len(args)-1])
 
 	if err != nil {
-		stderr("copy: %v", err)
+		stderr("copy-to-dir: %v", err)
 		return getErrorCode(err)
 	}
 

--- a/tests/copy_test.go
+++ b/tests/copy_test.go
@@ -207,7 +207,7 @@ func TestCopyManyDirs(t *testing.T) {
 	}
 
 	// golang--
-	err = runACBuildNoHist(workingDir, append([]string{"copy", "--to-dir"}, append(froms, dest)...)...)
+	err = runACBuildNoHist(workingDir, append([]string{"copy-to-dir"}, append(froms, dest)...)...)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -242,7 +242,7 @@ func TestCopyDirsAndFiles(t *testing.T) {
 	}
 
 	// golang--
-	err = runACBuildNoHist(workingDir, append([]string{"copy", "--to-dir"}, append(froms, dest)...)...)
+	err = runACBuildNoHist(workingDir, append([]string{"copy-to-dir"}, append(froms, dest)...)...)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}


### PR DESCRIPTION
Copy's semantics are weird and I don't like them, but there are
technical reasons preventing `acbuild copy` from being reasonable. This
commit breaks the --to-dir flag on `acbuild copy` out into a separate
command, so that when users notice that `acbuild copy` doesn't do what
they expect it'll be a little more obvious that there are two modes of
operation here. Hiding this away in a flag, and therefore inside a help
page that wasn't at the top level, wasn't very user friendly.

Fixes https://github.com/appc/acbuild/issues/163.