### PR TITLE
*: exit with error code 3 when arguments are invalid

### DIFF
--- a/acbuild/acbuild.go
+++ b/acbuild/acbuild.go
@@ -71,6 +71,8 @@ var (
 
 	cmdExitCode int
 
+	errCobra = fmt.Errorf("cobra error")
+
 	templFuncs = template.FuncMap{
 		"subcmdList": func(cmds []*cobra.Command) string {
 			var subcmds []string
@@ -106,6 +108,8 @@ func getErrorCode(err error) int {
 	switch err {
 	case lib.ErrNotFound:
 		return 2
+	case errCobra:
+		return 3
 	case nil:
 		return 0
 	default:
@@ -249,7 +253,10 @@ func main() {
 	// Make help just show the usage
 	cmdAcbuild.SetHelpTemplate(`{{.UsageString}}`)
 
-	cmdAcbuild.Execute()
+	err := cmdAcbuild.Execute()
+	if cmdExitCode == 0 && err != nil {
+		cmdExitCode = getErrorCode(errCobra)
+	}
 	os.Exit(cmdExitCode)
 }
 


### PR DESCRIPTION
If the user calls acbuild with invalid subcommands or flags, and the
code for no subcommand is called, acbuild would up until now exit with
exit code 0. This can break scripts relying on the exit code to catch
errors.

This commit changes this such that acbuild will exit with code 3 when
called with invalid subcommands or flags.

Fixes https://github.com/appc/acbuild/issues/160.