### PR TITLE
Fix panic when the prefix is > 61 chars

### DIFF
--- a/registry/fetch.go
+++ b/registry/fetch.go
@@ -414,7 +414,14 @@ func (r Registry) download(url, path, label string) error {
 func newIoprogress(label string, size int64, rdr io.Reader) io.Reader {
 	prefix := "Downloading " + label
 	fmtBytesSize := 18
+
+	// if barSize < 2, drawing the bar will panic; 3 will at least give a spinny
+	// thing.
 	barSize := int64(80 - len(prefix) - fmtBytesSize)
+	if barSize < 2 {
+		barSize = 2
+	}
+
 	bar := ioprogress.DrawTextFormatBarForW(barSize, os.Stderr)
 	fmtfunc := func(progress, total int64) string {
 		// Content-Length is set to -1 when unknown.


### PR DESCRIPTION
The `bar` function subtracts 2 from the barSize; if barSize is < 2, drawing the progress bar will panic because you can't `string.Repeat` a negative length.


```
Running: [/src/config.sh]
meta tag not found on XX.XXXXXXXXX.XXX/XXX-XXX/XXXX/XXXXXXX-XXXX-XXXXXXX: expected a 200 OK got 403
panic: runtime error: makeslice: len out of range

goroutine 1 [running]:
strings.Repeat(0x857ee0, 0x1, 0xfffffffffffffffe, 0x0, 0x0)
    /usr/lib/golang/src/strings/strings.go:458 +0x68
github.com/appc/acbuild/Godeps/_workspace/src/github.com/coreos/ioprogress.func·004(0x0, 0x37ae506, 0x0, 0x0)
    /root/acbuild/gopath/src/github.com/appc/acbuild/Godeps/_workspace/src/github.com/coreos/ioprogress/draw.go:112 +0x270
github.com/appc/acbuild/registry.func·002(0x0, 0x37ae506, 0x0, 0x0)
    /root/acbuild/gopath/src/github.com/appc/acbuild/registry/fetch.go:431 +0x1e7
```