### PR TITLE
Update Vagrant script to use Rkt 1.1.0

### DIFF
--- a/scripts/vagrant-install-acbuild.sh
+++ b/scripts/vagrant-install-acbuild.sh
@@ -7,6 +7,9 @@ pushd /vagrant
 ./build
 sudo cp -v bin/* /usr/local/bin
 
-curl -s -q -L -o rkt.tar.gz https://github.com/coreos/rkt/releases/download/v0.9.0/rkt-v0.9.0.tar.gz -z rkt.tar.gz
+curl -s -q -L -o rkt.tar.gz https://github.com/coreos/rkt/releases/download/v1.1.0/rkt-v1.1.0.tar.gz -z rkt.tar.gz
 tar xfv rkt.tar.gz
-sudo cp -v rkt-v0.9.0/* /usr/local/bin
+sudo cp -v rkt-v1.1.0/rkt /usr/local/bin
+sudo cp -v rkt-v1.1.0/*.aci /usr/local/bin
+sudo groupadd rkt
+sudo ./rkt-v1.1.0/scripts/setup-data-dir.sh


### PR DESCRIPTION
Currently the Vagrant install script uses Rkt 0.9.0. Version 1.1.0 was released recently, so update to that.

This was previously submitted as #183, but I renamed the branch, which confused GitHub...

Test Plan:
```sh
git clone https://github.com/coreos/coreos-baremetal.git
cd coreos-baremetal/contrib/dnsmasq
./get-tftp-files
sudo ./build-aci
```