### PR TITLE
run: add support for swappable engines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,15 @@ language: go
 matrix:
   include:
     - go: 1.4.2
-    - go: 1.5.1
+    - go: 1.5.3
+    - go: 1.6
 
 install:
  - 
 
 script:
  - ./build
- - ./test
+ - ./test -v
 
 notifications:
   email: false

--- a/Documentation/subcommands/run.md
+++ b/Documentation/subcommands/run.md
@@ -19,14 +19,20 @@ run` is to be used on a system without overlayfs, the ACI and its dependencies
 must be flattened into a single ACI without dependencies. A command called
 `acbuild squash` is being worked on to do this.
 
-## systemd-nspawn
+## Engines
 
-acbuild currently uses `systemd-nspawn` to run commands inside the ACI. This
-means that the machine running acbuild must have systemd installed to be able
-to use `acbuild run`. Alternate execution tools (like `runc`) will be added in
-the future.
+acbuild can use different engines to perform the actual execution of the given
+command. The flag `--engine` can be used to select a non-default engine.
 
-## Exiting out of systemd-nspawn
+### systemd-nspawn
+
+The default engine in acbuild is called `systemd-nspawn`, which rather
+obviously uses `systemd-nspawn` to run the given command. This means that the
+machine running acbuild must have systemd installed to be able to use `acbuild
+run` with the default engine. Alternate execution tools (like `runc`) will be
+added in the future.
+
+### Exiting out of systemd-nspawn
 
 All acbuild commands can be cancelled with Ctrl+c with the exception of
 `acbuild run` once it has executed systemd-nspawn. To break out of a

--- a/README.md
+++ b/README.md
@@ -27,10 +27,12 @@ Instructions on how to do this are a little further down in this document.
 acbuild requires a handful of commands be available on the system on 
 which it's run:
 
-- `systemd-nspawn`
 - `cp`
 - `modprobe`
 - `gpg`
+
+Additionally `systemd-nspawn` is required to use the [default
+engine](Documentation/subcommands/run.md) for acbuild run.
 
 ### Prebuilt Binaries
 

--- a/engine/common.go
+++ b/engine/common.go
@@ -1,0 +1,32 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"github.com/appc/spec/schema/types"
+)
+
+// Engine is an interface which is accepted by lib.Run, and used to perform the
+// actual execution of a binary inside the container.
+type Engine interface {
+	// Run executes a command inside a container. command is the path to the
+	// binary (post-chroot) to exec, args is the arguments to pass to the
+	// binary, environment is the set of environment variables to set for the
+	// binary, chroot is the path on the host where the container's root
+	// filesystem exists, and workingDir specifies the path inside the
+	// container that should be the current working directory for the binary.
+	// If workingDir is "", the default should be "/".
+	Run(command string, args []string, environment types.Environment, chroot, workingDir string) error
+}

--- a/engine/systemdnspawn/systemdnspawn.go
+++ b/engine/systemdnspawn/systemdnspawn.go
@@ -1,0 +1,135 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package systemdnspawn
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"syscall"
+
+	"github.com/appc/spec/schema/types"
+)
+
+var pathlist = []string{"/usr/local/sbin", "/usr/local/bin", "/usr/sbin",
+	"/usr/bin", "/sbin", "/bin"}
+
+type Engine struct{}
+
+func (e Engine) Run(command string, args []string, environment types.Environment, chroot, workingDir string) error {
+	nspawncmd := []string{"systemd-nspawn", "-D", chroot}
+
+	systemdVersion, err := getSystemdVersion()
+	if err != nil {
+		return err
+	}
+
+	if systemdVersion >= 209 {
+		nspawncmd = append(nspawncmd, "--quiet", "--register=no")
+	}
+	if workingDir != "" {
+		if systemdVersion < 229 {
+			return fmt.Errorf("the working dir can only be set on systems with systemd-nspawn >= 229")
+		}
+		nspawncmd = append(nspawncmd, "--chdir", workingDir)
+	}
+
+	for _, envVar := range environment {
+		nspawncmd = append(nspawncmd, "--setenv", envVar.Name+"="+envVar.Value)
+	}
+
+	nspawncmd = append(nspawncmd, "--setenv", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
+
+	abscmd, err := findCmdInPath(pathlist, command, chroot)
+	if err != nil {
+		return err
+	}
+
+	finfo, err := os.Lstat(path.Join(chroot, abscmd))
+	switch {
+	case os.IsNotExist(err):
+		return fmt.Errorf("binary %q doesn't exist", abscmd)
+	case err != nil:
+		return err
+	}
+
+	if finfo.Mode()&os.ModeSymlink != 0 && systemdVersion < 228 {
+		fmt.Fprintf(os.Stderr, "Warning: %q is a symlink, which systemd-nspawn version %d might error on\n", abscmd, systemdVersion)
+	}
+
+	nspawncmd = append(nspawncmd, abscmd)
+	nspawncmd = append(nspawncmd, args...)
+
+	execCmd := exec.Command(nspawncmd[0], nspawncmd[1:]...)
+	execCmd.Stdout = os.Stdout
+	execCmd.Stderr = os.Stderr
+	execCmd.Env = []string{"SYSTEMD_LOG_LEVEL=err"}
+
+	err = execCmd.Run()
+	if err == exec.ErrNotFound {
+		return fmt.Errorf("systemd-nspawn is required but not found")
+	}
+	if err == nil {
+		return nil
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		code := exitErr.Sys().(syscall.WaitStatus).ExitStatus()
+		return fmt.Errorf("non-zero exit code: %d", code)
+	}
+	return err
+}
+
+func getSystemdVersion() (int, error) {
+	_, err := exec.LookPath("systemctl")
+	if err == exec.ErrNotFound {
+		return 0, fmt.Errorf("system does not have systemd")
+	}
+
+	blob, err := exec.Command("systemctl", "--version").Output()
+	if err != nil {
+		return 0, err
+	}
+	for _, line := range strings.Split(string(blob), "\n") {
+		if strings.HasPrefix(line, "systemd ") {
+			var version int
+			_, err := fmt.Sscanf(line, "systemd %d", &version)
+			if err != nil {
+				return 0, err
+			}
+			return version, nil
+		}
+	}
+	return 0, fmt.Errorf("error parsing output from `systemctl --version`")
+}
+
+func findCmdInPath(pathlist []string, cmd, prefix string) (string, error) {
+	if path.IsAbs(cmd) {
+		return cmd, nil
+	}
+
+	for _, p := range pathlist {
+		_, err := os.Lstat(path.Join(prefix, p, cmd))
+		switch {
+		case os.IsNotExist(err):
+			continue
+		case err != nil:
+			return "", err
+		}
+		return path.Join(p, cmd), nil
+	}
+	return "", fmt.Errorf("%s not found in any of: %v", cmd, pathlist)
+}

--- a/tests/begin_test.go
+++ b/tests/begin_test.go
@@ -15,16 +15,10 @@
 package tests
 
 import (
-	"archive/tar"
-	"encoding/json"
 	"io/ioutil"
 	"os"
-	"path"
-	"path/filepath"
 	"testing"
 	"time"
-
-	"github.com/appc/spec/aci"
 )
 
 func TestBeginEmpty(t *testing.T) {
@@ -41,36 +35,14 @@ func TestBeginEmpty(t *testing.T) {
 }
 
 func TestBeginLocalACI(t *testing.T) {
-	manblob, err := json.Marshal(detailedManifest())
-	if err != nil {
-		panic(err)
-	}
-
-	tmpexpandedaci := mustTempDir()
-	defer os.RemoveAll(tmpexpandedaci)
-
-	err = ioutil.WriteFile(path.Join(tmpexpandedaci, aci.ManifestFile), manblob, 0644)
-	if err != nil {
-		panic(err)
-	}
-
-	err = os.Mkdir(path.Join(tmpexpandedaci, aci.RootfsDir), 0755)
-	if err != nil {
-		panic(err)
-	}
-
 	tmpaci, err := ioutil.TempFile("", "acbuild-test")
 	if err != nil {
 		panic(err)
 	}
 	defer os.RemoveAll(tmpaci.Name())
 
-	aw := aci.NewImageWriter(detailedManifest(), tar.NewWriter(tmpaci))
-	err = filepath.Walk(tmpexpandedaci, aci.BuildWalker(tmpexpandedaci, aw, nil))
-	aw.Close()
-	if err != nil {
-		panic(err)
-	}
+	makeACI(tmpaci, detailedManifest())
+
 	tmpaci.Close()
 
 	workingDir := mustTempDir()

--- a/tests/run_test.go
+++ b/tests/run_test.go
@@ -1,0 +1,101 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"testing"
+)
+
+const goprogram = `
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Printf("success")
+}
+`
+
+func TestRun(t *testing.T) {
+	if os.Getenv("ENABLE_SYSTEMD_TESTS") == "" {
+		t.Skip("skipping test; $ENABLE_SYSTEMD_TESTS not set")
+	}
+
+	// Build a statically linked test program
+	tmpsourcedir := mustTempDir()
+	defer os.RemoveAll(tmpsourcedir)
+	tmpsource := path.Join(tmpsourcedir, "thing.go")
+	defer os.RemoveAll(tmpsourcedir)
+	err := ioutil.WriteFile(tmpsource, []byte(goprogram), 0644)
+	if err != nil {
+		panic(err)
+	}
+
+	tmprootfs := mustTempDir()
+	defer os.RemoveAll(tmprootfs)
+
+	cmd := exec.Command("go", "build", "-o", path.Join(tmprootfs, "worker"), "-tags", "netgo", "-ldflags", "-w", tmpsource)
+	cmd.Env = []string{"CGO_ENABLED=0", "GOOS=linux", "GOROOT=" + os.Getenv("GOROOT"), "GOPATH=" + os.Getenv("GOPATH")}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Println(string(output))
+		panic(err)
+	}
+
+	// Call begin on it
+	tmpdir := mustTempDir()
+	_, _, _, err = runACBuild(tmpdir, "begin", tmprootfs)
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	// acbuild run the binary
+	_, stdout, stderr, err := runACBuild(tmpdir, "--no-history", "run", "/worker")
+	if err != nil {
+		panic(err)
+	}
+	if stderr != "" {
+		t.Errorf("stderr wasn't empty: %s", stderr)
+	}
+	if stdout != "success" {
+		t.Errorf("unexpected stdout: %s", stdout)
+	}
+}
+
+func TestRunBadEngine(t *testing.T) {
+	workingDir := setUpTest(t)
+	defer cleanUpTest(workingDir)
+
+	_, stdout, stderr, err := runACBuild(workingDir, "run", "--engine=invalid-engine", "command")
+	if err == nil {
+		t.Errorf("was not expecting err to be nil when run with invalid engine")
+	}
+
+	if stdout != "" {
+		t.Errorf("printed to stdout when should not have: %s", stdout)
+	}
+
+	if stderr != "run: no such engine \"invalid-engine\"\n" {
+		t.Errorf("unexpected message on stderr: %s", stderr)
+	}
+}


### PR DESCRIPTION
This commit revamps `lib/run.go` to rely on external binaries to perform
the actual execution of the desired command. Each external binary, or
engine, is expected to either exist on the PATH or in the same directory
as the acbuild binary, and must be named as `acbuild-$ENGINENAME`. The
default (and currently only) engine is systemd-nspawn.

When the engine is started a JSON message detailing what it is to run
and with what environment variables is written into it on stdin. The
package `github.com/appc/acbuild/engine` has been added to define the
schema for this (and also holds some helper utilities for engines).

Almost fixes https://github.com/appc/acbuild/issues/13.
Kind of a workaround for https://github.com/appc/acbuild/issues/162.