### PR TITLE
begin/copy: scan for arm executables, update arch label when found

### DIFF
--- a/Documentation/subcommands/label.md
+++ b/Documentation/subcommands/label.md
@@ -31,6 +31,22 @@ When an empty ACI is created with `acbuild begin`, by default the `os` and
 `arch` labels are created for you. Their default values are the current
 system's OS and architecture, as determined by golang's `runtime` package.
 
+## The Arch Label on ARM
+
+When `acbuild begin` is used without any starting image, `runtime.GOARCH` is
+used to determine the default value for the `arch` label. This doesn't
+differentiate between different arm versions, and according to the AppC spec
+acbuild needs to pick one of `armv6l`, `armv7l`, and `armv7b`.
+
+To account for this acbuild will inspect the endinanness of the machine it is
+running on and pick `armv7l` or `armv7b` accordingly. As a result if acbuild is
+on a platform where the label should be `armv6l`, the following command should
+be used to override the default label.
+
+```
+acbuild label add arch armv6l
+```
+
 ## Examples
 
 ```bash


### PR DESCRIPTION
The runtime.GOARCH value isn't accepted by the AppC spec as a value for
the arch label in a manifest when on an arm platform. This commit adds a
case to use "armv7l" whenever runtime.GOARCH is "arm". Additionally
(when on arm) this change scans all files at the build start and any
files copied in later for executables, and will switch the label between
"armv7l" and "armv7b" when it finds a little or big endian binary.

Fixes https://github.com/appc/acbuild/issues/190.