### PR TITLE
Mention the need for `systemd-container` on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ which it's run:
 - `gpg`
 
 Additionally `systemd-nspawn` is required to use the [default
-engine](Documentation/subcommands/run.md) for acbuild run.
+engine](Documentation/subcommands/run.md) for acbuild run. Thus on Ubuntu the `systemd-container` package needs to be installed.
 
 ### Prebuilt Binaries
 


### PR DESCRIPTION
Without the `systemd-container` package installed on Ubuntu there are no systemd container/nspawn tools.