### PR TITLE
vagrant: use xenial64 instead of vivid64

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 Vagrant.configure('2') do |config|
-    # grab Ubuntu 15.04 official image
-    config.vm.box = "ubuntu/vivid64" # Ubuntu 15.04
+    # grab Ubuntu 16.04 official image
+    config.vm.box = "ubuntu/xenial64" # Ubuntu 16.04
 
     # fix issues with slow dns http://serverfault.com/a/595010
     config.vm.provider :virtualbox do |vb, override|


### PR DESCRIPTION
The vivid64 image is no longer available.

Fixes https://github.com/appc/acbuild/issues/187.