### PR TITLE
readme: requires Go to build from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The easiest way to get `acbuild` is to download one of the
 
 ### Build from source
 
-The other way to get `acbuild` is to build it from source.
+The other way to get `acbuild` is to build it from source. Building from source requires [Go 1.5+](https://golang.org/dl/).
 
 Follow these steps to do so:
 


### PR DESCRIPTION
Go 1.5+ is needed to build from source, updates readme to reflect that.