### PR TITLE
docs: articulate the necessity of `--` in run and set-exec

### DIFF
--- a/Documentation/subcommands/run.md
+++ b/Documentation/subcommands/run.md
@@ -2,6 +2,13 @@
 
 `acbuild run` will run the given command inside the ACI.
 
+## Options Parsing
+
+acbuild needs to be able to differentiate between flags to acbuild and flags to
+pass along to the binary being run. This is accomplished with `--`. Any flags
+occurring before this are considered as being intended for acbuild, and any
+flags after it are assumed to belong to the command being run.
+
 ## Dependencies
 
 In order to be able to run the command, all dependencies of the current ACI

--- a/Documentation/subcommands/set-exec.md
+++ b/Documentation/subcommands/set-exec.md
@@ -1,5 +1,12 @@
 # acbuild set-exec
 
-* `acbuild set-exec CMD [ARGS]`
+* `acbuild set-exec -- CMD [ARGS]`
 
   Sets the exec command in the ACI's manifest.
+
+## Options Parsing
+
+acbuild needs to be able to differentiate between flags to acbuild and flags to
+pass along to the binary being run. This is accomplished with `--`. Any flags
+occurring before this are considered as being intended for acbuild, and any
+flags after it are assumed to belong to the command being run.

--- a/acbuild/run.go
+++ b/acbuild/run.go
@@ -29,10 +29,10 @@ var (
 	workingdir = ""
 	engineName = ""
 	cmdRun     = &cobra.Command{
-		Use:     "run CMD [ARGS]",
+		Use:     "run -- CMD [ARGS]",
 		Short:   "Run a command in an ACI",
 		Long:    "Run a given command in an ACI, and save the resulting container as a new ACI",
-		Example: "acbuild run yum install nginx",
+		Example: "acbuild run -- yum install nginx",
 		Run:     runWrapper(runRun),
 	}
 

--- a/acbuild/set-exec.go
+++ b/acbuild/set-exec.go
@@ -20,10 +20,10 @@ import (
 
 var (
 	cmdSetExec = &cobra.Command{
-		Use:     "set-exec CMD [ARGS]",
+		Use:     "set-exec -- CMD [ARGS]",
 		Short:   "Set the exec command",
 		Long:    "Sets the exec command in the ACI's manifest",
-		Example: "acbuild set-exec /usr/sbin/nginx -g \"daemon off;\"",
+		Example: "acbuild set-exec -- /usr/sbin/nginx -g \"daemon off;\"",
 		Run:     runWrapper(runSetExec),
 	}
 )


### PR DESCRIPTION
The -- flag influences how acbuild determines which flags are intended
for itself and which flags to pass along, but this was missing from the
examples and documentation.

Fixes https://github.com/appc/acbuild/issues/213.