### PR TITLE
release: v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v0.3.1
+
+appc spec version: v0.8.4
+
+This minor release largely exists to bump the version of the AppC spec the
+acbuild is using.
+
+- Bumps the version of the AppC spec to v0.8.4.
+- Adds the ability for acbuild to generate man pages for itself.
+
 ## v0.3.0
 
 appc spec version: v0.7.4


### PR DESCRIPTION
Made this release as per @onlyjob's request [here](https://github.com/appc/acbuild/issues/199).

Only changes since v0.3.0 is the ability to generate man pages, and the version of the AppC spec used (now v0.8.4, was v0.7.4)

I want to merge this change before the release gets merged: https://github.com/appc/acbuild/pull/218