### PR TITLE
engine/systemdnspawn: copy in the host's /etc/machine-id for >= 230

### DIFF
--- a/engine/systemdnspawn/systemdnspawn.go
+++ b/engine/systemdnspawn/systemdnspawn.go
@@ -47,6 +47,25 @@ func (e Engine) Run(command string, args []string, environment types.Environment
 		}
 		nspawncmd = append(nspawncmd, "--chdir", workingDir)
 	}
+	if systemdVersion >= 230 {
+		machineIdFile := path.Join(chroot, "/etc/machine-id")
+		_, err := os.Stat(machineIdFile)
+		switch {
+		case os.IsNotExist(err):
+			err := os.MkdirAll(path.Dir(machineIdFile), 0755)
+			if err != nil {
+				return err
+			}
+			f, err := os.Create(machineIdFile)
+			if err != nil {
+				return err
+			}
+			f.Close()
+			defer os.RemoveAll(path.Join(chroot, machineIdFile))
+		case err != nil:
+			return err
+		}
+	}
 
 	for _, envVar := range environment {
 		nspawncmd = append(nspawncmd, "--setenv", envVar.Name+"="+envVar.Value)


### PR DESCRIPTION
Starting in systemd 230, systemd-nspawn requires the file
/etc/machine-id to be populated in the container for some reason. There
does not appear to be a flag to disable this, and the commit message I
found for the systemd commit that I think causes this is rather vague as
to why this is necessary.

To work around this, this commit copies /etc/machine-id in from the host
and removes it after the command has run.

Fixes https://github.com/appc/acbuild/issues/217.