### PR TITLE
engine: attach stdin to the process

### DIFF
--- a/engine/systemdnspawn/systemdnspawn.go
+++ b/engine/systemdnspawn/systemdnspawn.go
@@ -75,6 +75,7 @@ func (e Engine) Run(command string, args []string, environment types.Environment
 	nspawncmd = append(nspawncmd, args...)
 
 	execCmd := exec.Command(nspawncmd[0], nspawncmd[1:]...)
+	execCmd.Stdin = os.Stdin
 	execCmd.Stdout = os.Stdout
 	execCmd.Stderr = os.Stderr
 	execCmd.Env = []string{"SYSTEMD_LOG_LEVEL=err"}


### PR DESCRIPTION
This commit attaches stdin to the process executed during run commands,
which allows the user to pipe data into this process.

```
derek@proton ~/go/src/github.com/appc/acbuild> sudo ./bin/acbuild begin quay.io/coreos/alpine-sh           
Downloading quay.io/coreos/alpine-sh: [========================] 2.65 MB/2.65 MB
derek@proton ~/go/src/github.com/appc/acbuild> echo "this is a test" | sudo ./bin/acbuild run -- dd of=/test
0+1 records in
0+1 records out
derek@proton ~/go/src/github.com/appc/acbuild> sudo ./bin/acbuild run -- cat /test                          
this is a test
```

Fixes https://github.com/appc/acbuild/issues/200.