### PR TITLE
do not install git again if it exists

### DIFF
--- a/scripts/vagrant-install-go.sh
+++ b/scripts/vagrant-install-go.sh
@@ -28,4 +28,4 @@ export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 EOF
 
 # not essential but go get depends on it
-which git || sudo apt-get update && sudo apt-get install -y git
+which git || { sudo apt-get update && sudo apt-get install -y git; }


### PR DESCRIPTION
Currently the which git check is irrelevant. This combines the two actions in the same logic. 

$ true || echo "false" && echo "not needed"
not needed

$ true || { echo "false" && echo "not needed"; }
$